### PR TITLE
docs: FAQ 하단 문의하기 링크 변경 (한/영)

### DIFF
--- a/content/docs/en/help-center/faq.mdx
+++ b/content/docs/en/help-center/faq.mdx
@@ -135,7 +135,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
   <span className="block text-lg font-bold text-[#1A2C5C] mb-1">Didn't find what you were looking for?</span>
   <span className="block text-[#76809D] text-sm mb-4">The Walla team will get back to you quickly.</span>
   <div className="flex justify-center">
-    <a href="mailto:cs@walla.my" className="inline-flex items-center justify-center rounded-full bg-[hsl(193,100%,50%)] px-5 py-2 text-sm font-bold text-white hover:opacity-90 transition-opacity no-underline">
+    <a href="https://walla.my/survey/9Z04inEDzv9XKqVC7d14?source=helpcenter-faq" className="inline-flex items-center justify-center rounded-full bg-[hsl(193,100%,50%)] px-5 py-2 text-sm font-bold text-white hover:opacity-90 transition-opacity no-underline">
       Contact us →
     </a>
   </div>

--- a/content/docs/ko/help-center/faq.mdx
+++ b/content/docs/ko/help-center/faq.mdx
@@ -135,7 +135,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
   <span className="block text-lg font-bold text-[#1A2C5C] mb-1">원하는 답변을 찾지 못하셨나요?</span>
   <span className="block text-[#76809D] text-sm mb-4">왈라팀이 빠르게 답변드릴게요.</span>
   <div className="flex justify-center">
-    <a href="mailto:cs@walla.my" className="inline-flex items-center justify-center rounded-full bg-[hsl(193,100%,50%)] px-5 py-2 text-sm font-bold text-white hover:opacity-90 transition-opacity no-underline">
+    <a href="https://walla.my/survey/9Z04inEDzv9XKqVC7d14?source=helpcenter-faq" className="inline-flex items-center justify-center rounded-full bg-[hsl(193,100%,50%)] px-5 py-2 text-sm font-bold text-white hover:opacity-90 transition-opacity no-underline">
       문의하기 →
     </a>
   </div>


### PR DESCRIPTION
## 변경 내용

- FAQ 페이지 하단 "문의하기" 버튼 링크 변경 (한국어/영어)
  - 기존: `mailto:cs@walla.my`
  - 변경: `https://walla.my/survey/9Z04inEDzv9XKqVC7d14?source=helpcenter-faq`

🤖 Generated with [Claude Code](https://claude.com/claude-code)