### PR TITLE
docs(developer): _observedFields picker + ObservedFieldRef (PPRKD-4521 / PPRKD-4554)

### DIFF
--- a/content/docs/en/developer-docs/custom-fields-api-reference.mdx
+++ b/content/docs/en/developer-docs/custom-fields-api-reference.mdx
@@ -277,7 +277,7 @@ Returns the current form context (other fields' metadata and values). The conten
 field.getObservedFields(): ObservedFieldRef[]
 ```
 
-Returns the references the form author selected for this custom field instance via the dashboard picker. Empty when the version's `observeFields` mode is not `'configured'` or no refs are configured. Order matches the picker order — meaningful for ordered consumers like a `diff` operator.
+Returns the references the form author has selected for this custom field instance. Empty when the version's `observeFields` mode is not `'configured'` or when no refs are configured. Order is preserved — meaningful for ordered consumers like a `diff` operator.
 
 ```typescript
 field.onInit(({ observedFields, formContext }) => {

--- a/content/docs/en/developer-docs/custom-fields-api-reference.mdx
+++ b/content/docs/en/developer-docs/custom-fields-api-reference.mdx
@@ -271,6 +271,28 @@ field.getFormContext(): { fields: FieldSummary[]; values: Record<string, unknown
 
 Returns the current form context (other fields' metadata and values). The content depends on the `observeFields` policy.
 
+### getObservedFields
+
+```typescript
+field.getObservedFields(): ObservedFieldRef[]
+```
+
+Returns the references the form author selected for this custom field instance via the dashboard picker. Empty when the version's `observeFields` mode is not `'configured'` or no refs are configured. Order matches the picker order — meaningful for ordered consumers like a `diff` operator.
+
+```typescript
+field.onInit(({ observedFields, formContext }) => {
+  for (const ref of observedFields) {
+    if (ref.kind === 'field') {
+      const value = formContext.values[ref.id];
+      // ...
+    } else {
+      const summary = formContext.fields.find(f => f.label === ref.label);
+      // ...
+    }
+  }
+});
+```
+
 ### isConnected
 
 ```typescript
@@ -305,6 +327,7 @@ interface FieldInitPayload {
   mode: 'live' | 'preview';
   fieldInfo: WallaFieldInfo;
   properties: Record<string, unknown>;
+  observedFields: ObservedFieldRef[];
   value: unknown | null;
   theme: WallaFieldTheme;
   locale: string;
@@ -382,6 +405,23 @@ interface FieldSummary {
 ```
 
 The `customField` property is present only when `fieldType` is `'CUSTOM'`.
+
+### ObservedFieldRef
+
+A typed reference to another field in the form, configured by the form author when the version's `observeFields` mode is `'configured'`. Delivered as `payload.observedFields` and via `field.getObservedFields()`.
+
+```typescript
+type ObservedFieldRef =
+  | { kind: 'field';  id: string }     // Regular form field, resolved by id
+  | { kind: 'hidden'; label: string }; // Hidden field (URL query parameter), resolved by author-defined label
+```
+
+| Variant | Identity | Resolution |
+|---------|----------|------------|
+| `field` | `id` (uuid) | `formContext.values[id]` |
+| `hidden` | `label` (e.g., `utm_discount`) | `formContext.fields.find(f => f.label === label)` |
+
+Order is preserved across saves — meaningful for ordered consumers (e.g., a calculator's `diff` operator).
 
 ### ValidateCallback
 

--- a/content/docs/en/developer-docs/custom-fields-lifecycle.mdx
+++ b/content/docs/en/developer-docs/custom-fields-lifecycle.mdx
@@ -251,9 +251,9 @@ Custom fields can observe other fields' metadata and values. The available data 
 
 > Sensitive field types (`SECRETS`, `PHONE_NUMBER`, `EMAIL`) are always excluded from form context, even in `all` mode.
 
-### Configured mode — selecting which fields to observe
+### Configured mode — declaring observed fields
 
-When `observeFields.mode === 'configured'`, the form author picks specific fields via a picker rendered in the dashboard. Define an `_observedFields` property in your properties schema (see [Properties Schema → Cross-field references](./custom-fields-properties-schema)) and the dashboard will swap a dropdown picker in for that property. Refs are stored in the picker order and delivered to your iframe as a typed `ObservedFieldRef[]`:
+Set `observeFields.mode` to `'configured'` on your custom field version and declare an `_observedFields` array in your properties schema (see [Properties Schema → Cross-field references](./custom-fields-properties-schema)). The form author selects which fields to observe at authoring time; at runtime your iframe receives the resolved selection as a typed `ObservedFieldRef[]`:
 
 ```typescript
 type ObservedFieldRef =

--- a/content/docs/en/developer-docs/custom-fields-lifecycle.mdx
+++ b/content/docs/en/developer-docs/custom-fields-lifecycle.mdx
@@ -247,9 +247,37 @@ Custom fields can observe other fields' metadata and values. The available data 
 |------|---------------------|---------------------|----------|
 | `none` | Empty | Empty | Standalone fields (color picker, signature) |
 | `all` | All fields (sensitive excluded) | All values | Summary, calculation fields |
-| `configured` | Admin-selected fields | Selected values | Fields that reference specific inputs |
+| `configured` | Author-selected fields | Selected values | Fields that reference specific inputs |
 
 > Sensitive field types (`SECRETS`, `PHONE_NUMBER`, `EMAIL`) are always excluded from form context, even in `all` mode.
+
+### Configured mode — selecting which fields to observe
+
+When `observeFields.mode === 'configured'`, the form author picks specific fields via a picker rendered in the dashboard. Define an `_observedFields` property in your properties schema (see [Properties Schema → Cross-field references](./custom-fields-properties-schema)) and the dashboard will swap a dropdown picker in for that property. Refs are stored in the picker order and delivered to your iframe as a typed `ObservedFieldRef[]`:
+
+```typescript
+type ObservedFieldRef =
+  | { kind: 'field';  id: string }     // Regular field, resolve via formContext.values[id]
+  | { kind: 'hidden'; label: string }; // Hidden field, resolve via formContext.fields.find(f => f.label === label)
+```
+
+Use them on init to wire up your computation:
+
+```typescript
+field.onInit(({ observedFields, formContext }) => {
+  for (const ref of observedFields) {
+    if (ref.kind === 'field') {
+      const value = formContext.values[ref.id];
+      // ...
+    } else {
+      const field = formContext.fields.find(f => f.label === ref.label);
+      // ...
+    }
+  }
+});
+```
+
+The granted set in `formContext` may be smaller than `observedFields` — sensitive types are dropped silently and refs to fields that have since been deleted resolve to nothing. Code defensively.
 
 ### Receiving initial context
 

--- a/content/docs/en/developer-docs/custom-fields-properties-schema.mdx
+++ b/content/docs/en/developer-docs/custom-fields-properties-schema.mdx
@@ -68,6 +68,93 @@ The `defaultProperties` object provides initial values when a form builder adds 
 }
 ```
 
+### Cross-field references (`_observedFields`)
+
+Some custom fields need values from other fields in the same form — a calculator that sums quantities, a price preview that reflects user choices, a summary that quotes earlier answers. Use the system-reserved `_observedFields` property to let the form author select which fields to observe.
+
+The `_` prefix marks the key as system-managed. Don't redefine it in your own properties — Walla validates each ref, then hoists the array to the typed `payload.observedFields` field on `FieldInitPayload` so your iframe doesn't need to know the storage key.
+
+Declare the property as a tagged-union array. The two `oneOf` branches correspond to regular form fields (referenced by id) and hidden fields (referenced by their author-defined label):
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "operator": {
+      "type": "string",
+      "enum": ["sum", "product", "diff", "min", "max", "avg"],
+      "default": "sum"
+    },
+    "_observedFields": {
+      "type": "array",
+      "title": "Observed fields",
+      "description": "Fields whose values this calculator combines.",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "Regular field reference",
+            "properties": {
+              "kind": { "const": "field" },
+              "id":   { "type": "string", "title": "Field id" }
+            },
+            "required": ["kind", "id"]
+          },
+          {
+            "type": "object",
+            "title": "Hidden field reference",
+            "properties": {
+              "kind":  { "const": "hidden" },
+              "label": { "type": "string", "title": "Hidden field label" }
+            },
+            "required": ["kind", "label"]
+          }
+        ]
+      },
+      "default": []
+    }
+  },
+  "required": ["operator"]
+}
+```
+
+#### Picker UI
+
+When the dashboard detects this exact shape (an array whose `items.oneOf` has the `kind: 'field' | 'hidden'` discriminator), it replaces the generic JSON editor with an interactive picker. The picker shows two grouped sections in a single dropdown:
+
+- **Form responses** — regular fields the author has added (in form order, with type badges)
+- **Query parameters** — hidden fields configured on the share / distribute page
+
+The author selects refs from the dropdown; selected items are listed in a draggable rail above the picker, and order is preserved on save (semantic for ordered consumers like the `diff` operator). Refs to fields that have since been removed are shown as "(deleted)" so the author can prune them.
+
+The picker reads from the **draft** form (the in-edit YJS document), so newly-added or renamed fields appear immediately — the form does not need to be published before the author can reference them.
+
+#### What your iframe receives
+
+Set the version's `observeFields.mode` to `'configured'`. After the author picks refs, your iframe receives them via `payload.observedFields` and the resolved values via `payload.formContext`:
+
+```typescript
+field.onInit(({ observedFields, formContext, properties }) => {
+  // observedFields: [
+  //   { kind: 'field',  id: 'fld_qty'   },
+  //   { kind: 'field',  id: 'fld_price' },
+  //   { kind: 'hidden', label: 'utm_discount' },
+  // ]
+  // formContext.fields: typed FieldSummary[] for each granted field
+  // formContext.values: { [id]: value } — granted subset only
+
+  const operands = observedFields.map(ref => {
+    if (ref.kind === 'field') return Number(formContext.values[ref.id] ?? 0);
+    const f = formContext.fields.find(field => field.label === ref.label);
+    return Number(formContext.values[f?.id ?? ''] ?? 0);
+  });
+
+  field.setValue(operands.reduce((a, b) => a + b, 0));
+});
+```
+
+> Sensitive field types (`SECRETS`, `PHONE_NUMBER`, `EMAIL`) are stripped from `formContext` even when explicitly listed in `observedFields`. The granted set is always a strict subset of the requested set.
+
 ## Output Schema
 
 The `outputSchema` is a JSON Schema that defines the shape of values your field produces when submitted. Walla uses this schema to:

--- a/content/docs/en/developer-docs/custom-fields-properties-schema.mdx
+++ b/content/docs/en/developer-docs/custom-fields-properties-schema.mdx
@@ -118,20 +118,17 @@ Declare the property as a tagged-union array. The two `oneOf` branches correspon
 }
 ```
 
-#### Picker UI
+#### Selection model
 
-When the dashboard detects this exact shape (an array whose `items.oneOf` has the `kind: 'field' | 'hidden'` discriminator), it replaces the generic JSON editor with an interactive picker. The picker shows two grouped sections in a single dropdown:
+Form authors choose refs at authoring time — they don't need to publish the form first to reference newly-added fields. Selections are persisted in the order chosen, which matters for ordered consumers like a `diff` or list-based operator.
 
-- **Form responses** — regular fields the author has added (in form order, with type badges)
-- **Query parameters** — hidden fields configured on the share / distribute page
+Refs may point to fields that no longer exist (a hidden field renamed, a regular field deleted). Those refs simply do not resolve in `formContext` at runtime — your iframe should iterate `observedFields` defensively rather than assume every ref maps to a value.
 
-The author selects refs from the dropdown; selected items are listed in a draggable rail above the picker, and order is preserved on save (semantic for ordered consumers like the `diff` operator). Refs to fields that have since been removed are shown as "(deleted)" so the author can prune them.
-
-The picker reads from the **draft** form (the in-edit YJS document), so newly-added or renamed fields appear immediately — the form does not need to be published before the author can reference them.
+The host's authoring UI groups the two `oneOf` branches so authors can select refs without editing JSON. The exact UI is host-specific; the contract you can rely on is the on-the-wire shape — `ObservedFieldRef[]` in the order the author chose.
 
 #### What your iframe receives
 
-Set the version's `observeFields.mode` to `'configured'`. After the author picks refs, your iframe receives them via `payload.observedFields` and the resolved values via `payload.formContext`:
+Set the version's `observeFields.mode` to `'configured'`. Once an author has selected refs, your iframe receives them via `payload.observedFields`, with resolved values in `payload.formContext`:
 
 ```typescript
 field.onInit(({ observedFields, formContext, properties }) => {

--- a/content/docs/ko/developer-docs/custom-fields-api-reference.mdx
+++ b/content/docs/ko/developer-docs/custom-fields-api-reference.mdx
@@ -271,6 +271,28 @@ field.getFormContext(): { fields: FieldSummary[]; values: Record<string, unknown
 
 현재 폼 컨텍스트(다른 필드의 메타데이터와 값)를 반환합니다. 내용은 `observeFields` 정책에 따라 달라집니다.
 
+### getObservedFields
+
+```typescript
+field.getObservedFields(): ObservedFieldRef[]
+```
+
+대시보드 picker에서 폼 작성자가 이 커스텀 필드 인스턴스에 대해 선택한 참조 목록을 반환합니다. 버전의 `observeFields` 모드가 `'configured'`가 아니거나 선택된 참조가 없으면 빈 배열을 반환합니다. 순서는 picker 순서를 그대로 유지하며, `diff` 같은 순서-의존 연산자에 의미가 있습니다.
+
+```typescript
+field.onInit(({ observedFields, formContext }) => {
+  for (const ref of observedFields) {
+    if (ref.kind === 'field') {
+      const value = formContext.values[ref.id];
+      // ...
+    } else {
+      const summary = formContext.fields.find(f => f.label === ref.label);
+      // ...
+    }
+  }
+});
+```
+
 ### isConnected
 
 ```typescript
@@ -305,6 +327,7 @@ interface FieldInitPayload {
   mode: 'live' | 'preview';
   fieldInfo: WallaFieldInfo;
   properties: Record<string, unknown>;
+  observedFields: ObservedFieldRef[];
   value: unknown | null;
   theme: WallaFieldTheme;
   locale: string;
@@ -382,6 +405,23 @@ interface FieldSummary {
 ```
 
 `customField` 속성은 `fieldType`이 `'CUSTOM'`인 경우에만 존재합니다.
+
+### ObservedFieldRef
+
+버전의 `observeFields` 모드가 `'configured'`일 때 폼 작성자가 선택한 다른 필드에 대한 타입 안전한 참조입니다. `payload.observedFields`로 전달되며 `field.getObservedFields()`로도 조회할 수 있습니다.
+
+```typescript
+type ObservedFieldRef =
+  | { kind: 'field';  id: string }     // 일반 폼 필드, id로 식별
+  | { kind: 'hidden'; label: string }; // Hidden 필드 (URL 쿼리 파라미터), 작성자가 정의한 label로 식별
+```
+
+| 종류 | 식별자 | 해석 방법 |
+|------|--------|-----------|
+| `field` | `id` (uuid) | `formContext.values[id]` |
+| `hidden` | `label` (예: `utm_discount`) | `formContext.fields.find(f => f.label === label)` |
+
+저장 시 순서가 보존됩니다 — `diff` 연산자처럼 순서가 의미 있는 소비자에게 중요합니다.
 
 ### ValidateCallback
 

--- a/content/docs/ko/developer-docs/custom-fields-api-reference.mdx
+++ b/content/docs/ko/developer-docs/custom-fields-api-reference.mdx
@@ -277,7 +277,7 @@ field.getFormContext(): { fields: FieldSummary[]; values: Record<string, unknown
 field.getObservedFields(): ObservedFieldRef[]
 ```
 
-폼 작성자가 이 커스텀 필드 인스턴스에 대해 선택한 참조 목록을 반환합니다. 버전의 `observeFields` 모드가 `'configured'`가 아니거나 선택된 참조가 없으면 빈 배열을 반환합니다. 순서는 작성자가 고른 그대로 유지되며, `diff` 같은 순서-의존 연산자에 의미가 있습니다.
+폼 작성자가 이 커스텀 필드 인스턴스에 대해 선택한 참조 목록을 반환합니다. 버전의 `observeFields` 모드가 `'configured'`가 아니거나 선택된 참조가 없으면 빈 배열을 반환합니다. 순서는 작성자가 고른 그대로 유지되며, `diff`처럼 순서에 의존하는 연산자에서 의미가 있습니다.
 
 ```typescript
 field.onInit(({ observedFields, formContext }) => {
@@ -408,7 +408,7 @@ interface FieldSummary {
 
 ### ObservedFieldRef
 
-버전의 `observeFields` 모드가 `'configured'`일 때 폼 작성자가 선택한 다른 필드에 대한 타입 안전한 참조입니다. `payload.observedFields`로 전달되며 `field.getObservedFields()`로도 조회할 수 있습니다.
+버전의 `observeFields` 모드가 `'configured'`일 때 폼 작성자가 선택한 다른 필드에 대한, 타입이 지정된 참조입니다. `payload.observedFields`로 전달되며 `field.getObservedFields()`로도 조회할 수 있습니다.
 
 ```typescript
 type ObservedFieldRef =
@@ -421,7 +421,7 @@ type ObservedFieldRef =
 | `field` | `id` (uuid) | `formContext.values[id]` |
 | `hidden` | `label` (예: `utm_discount`) | `formContext.fields.find(f => f.label === label)` |
 
-저장 시 순서가 보존됩니다 — `diff` 연산자처럼 순서가 의미 있는 소비자에게 중요합니다.
+저장 시 순서가 보존됩니다 — `diff` 연산자처럼 순서를 사용하는 곳에서 의미가 있습니다.
 
 ### ValidateCallback
 

--- a/content/docs/ko/developer-docs/custom-fields-api-reference.mdx
+++ b/content/docs/ko/developer-docs/custom-fields-api-reference.mdx
@@ -277,7 +277,7 @@ field.getFormContext(): { fields: FieldSummary[]; values: Record<string, unknown
 field.getObservedFields(): ObservedFieldRef[]
 ```
 
-대시보드 picker에서 폼 작성자가 이 커스텀 필드 인스턴스에 대해 선택한 참조 목록을 반환합니다. 버전의 `observeFields` 모드가 `'configured'`가 아니거나 선택된 참조가 없으면 빈 배열을 반환합니다. 순서는 picker 순서를 그대로 유지하며, `diff` 같은 순서-의존 연산자에 의미가 있습니다.
+폼 작성자가 이 커스텀 필드 인스턴스에 대해 선택한 참조 목록을 반환합니다. 버전의 `observeFields` 모드가 `'configured'`가 아니거나 선택된 참조가 없으면 빈 배열을 반환합니다. 순서는 작성자가 고른 그대로 유지되며, `diff` 같은 순서-의존 연산자에 의미가 있습니다.
 
 ```typescript
 field.onInit(({ observedFields, formContext }) => {

--- a/content/docs/ko/developer-docs/custom-fields-lifecycle.mdx
+++ b/content/docs/ko/developer-docs/custom-fields-lifecycle.mdx
@@ -251,9 +251,9 @@ field.onFocus(() => {
 
 > 민감 필드 타입(`SECRETS`, `PHONE_NUMBER`, `EMAIL`)은 `all` 모드에서도 항상 폼 컨텍스트에서 제외됩니다.
 
-### Configured 모드 — 관찰할 필드 선택
+### Configured 모드 — 관찰할 필드 선언
 
-`observeFields.mode === 'configured'`일 때, 폼 작성자가 대시보드에 렌더링되는 picker로 특정 필드를 직접 선택합니다. properties 스키마에 `_observedFields` 키를 정의하면 ([속성 스키마 → 다른 필드 참조](./custom-fields-properties-schema) 참조), 대시보드가 그 자리에 dropdown picker를 swap해 보여줍니다. 선택된 참조는 picker 순서대로 저장되어 iframe에 타입 안전한 `ObservedFieldRef[]`로 전달됩니다:
+커스텀 필드 버전의 `observeFields.mode`를 `'configured'`로 설정하고, properties 스키마에 `_observedFields` 배열을 선언하세요 ([속성 스키마 → 다른 필드 참조](./custom-fields-properties-schema) 참조). authoring 시점에 폼 작성자가 어떤 필드를 관찰할지 선택하면, runtime에 iframe은 그 결과를 타입 안전한 `ObservedFieldRef[]`로 받습니다:
 
 ```typescript
 type ObservedFieldRef =

--- a/content/docs/ko/developer-docs/custom-fields-lifecycle.mdx
+++ b/content/docs/ko/developer-docs/custom-fields-lifecycle.mdx
@@ -253,7 +253,7 @@ field.onFocus(() => {
 
 ### Configured 모드 — 관찰할 필드 선언
 
-커스텀 필드 버전의 `observeFields.mode`를 `'configured'`로 설정하고, properties 스키마에 `_observedFields` 배열을 선언하세요 ([속성 스키마 → 다른 필드 참조](./custom-fields-properties-schema) 참조). authoring 시점에 폼 작성자가 어떤 필드를 관찰할지 선택하면, runtime에 iframe은 그 결과를 타입 안전한 `ObservedFieldRef[]`로 받습니다:
+커스텀 필드 버전의 `observeFields.mode`를 `'configured'`로 설정하고, properties 스키마에 `_observedFields` 배열을 선언하세요 ([속성 스키마 → 다른 필드 참조](./custom-fields-properties-schema) 참조). 폼 작성 시점에 작성자가 어떤 필드를 관찰할지 선택하면, 런타임에 iframe은 그 결과를 타입이 지정된 `ObservedFieldRef[]`로 받습니다:
 
 ```typescript
 type ObservedFieldRef =
@@ -261,7 +261,7 @@ type ObservedFieldRef =
   | { kind: 'hidden'; label: string }; // Hidden 필드, formContext.fields.find(f => f.label === label)로 해석
 ```
 
-init 시점에 활용 예시:
+초기화 시점 활용 예시:
 
 ```typescript
 field.onInit(({ observedFields, formContext }) => {
@@ -277,7 +277,7 @@ field.onInit(({ observedFields, formContext }) => {
 });
 ```
 
-`formContext`로 받는 granted 집합은 `observedFields`보다 작을 수 있습니다 — 민감 타입은 자동으로 제외되고, 이미 삭제된 필드를 가리키는 참조는 해석에 실패합니다. 방어적으로 코딩하세요.
+`formContext`로 받는 허용 집합은 `observedFields`보다 작을 수 있습니다 — 민감 타입은 자동으로 제외되고, 이미 삭제된 필드를 가리키는 참조는 해석되지 않습니다. 방어적으로 코딩하세요.
 
 ### 초기 컨텍스트 수신
 

--- a/content/docs/ko/developer-docs/custom-fields-lifecycle.mdx
+++ b/content/docs/ko/developer-docs/custom-fields-lifecycle.mdx
@@ -247,9 +247,37 @@ field.onFocus(() => {
 |------|---------------------|---------------------|----------|
 | `none` | 빈 배열 | 빈 객체 | 독립형 필드 (색상 선택기, 서명) |
 | `all` | 전체 필드 (민감 필드 제외) | 전체 값 | 요약, 계산 필드 |
-| `configured` | 관리자가 선택한 필드 | 선택된 값 | 특정 입력을 참조하는 필드 |
+| `configured` | 작성자가 선택한 필드 | 선택된 값 | 특정 입력을 참조하는 필드 |
 
 > 민감 필드 타입(`SECRETS`, `PHONE_NUMBER`, `EMAIL`)은 `all` 모드에서도 항상 폼 컨텍스트에서 제외됩니다.
+
+### Configured 모드 — 관찰할 필드 선택
+
+`observeFields.mode === 'configured'`일 때, 폼 작성자가 대시보드에 렌더링되는 picker로 특정 필드를 직접 선택합니다. properties 스키마에 `_observedFields` 키를 정의하면 ([속성 스키마 → 다른 필드 참조](./custom-fields-properties-schema) 참조), 대시보드가 그 자리에 dropdown picker를 swap해 보여줍니다. 선택된 참조는 picker 순서대로 저장되어 iframe에 타입 안전한 `ObservedFieldRef[]`로 전달됩니다:
+
+```typescript
+type ObservedFieldRef =
+  | { kind: 'field';  id: string }     // 일반 필드, formContext.values[id]로 해석
+  | { kind: 'hidden'; label: string }; // Hidden 필드, formContext.fields.find(f => f.label === label)로 해석
+```
+
+init 시점에 활용 예시:
+
+```typescript
+field.onInit(({ observedFields, formContext }) => {
+  for (const ref of observedFields) {
+    if (ref.kind === 'field') {
+      const value = formContext.values[ref.id];
+      // ...
+    } else {
+      const field = formContext.fields.find(f => f.label === ref.label);
+      // ...
+    }
+  }
+});
+```
+
+`formContext`로 받는 granted 집합은 `observedFields`보다 작을 수 있습니다 — 민감 타입은 자동으로 제외되고, 이미 삭제된 필드를 가리키는 참조는 해석에 실패합니다. 방어적으로 코딩하세요.
 
 ### 초기 컨텍스트 수신
 

--- a/content/docs/ko/developer-docs/custom-fields-properties-schema.mdx
+++ b/content/docs/ko/developer-docs/custom-fields-properties-schema.mdx
@@ -72,7 +72,7 @@ field.onInit(({ properties }) => {
 
 수량을 합산하는 계산기, 사용자 선택을 반영하는 가격 미리보기, 이전 답변을 인용하는 요약 — 이런 커스텀 필드는 같은 폼 내 다른 필드의 값이 필요합니다. 시스템 예약 키 `_observedFields`를 properties 스키마에 선언하면, 폼 작성자가 어떤 필드를 관찰할지 직접 선택할 수 있습니다.
 
-`_` 접두사는 시스템 관리 키임을 표시합니다 — 작성자가 직접 정의한 다른 properties와 겹치지 않게 별도 네임스페이스를 차지합니다. Walla가 각 참조를 검증한 뒤 `FieldInitPayload`의 타입 안전한 `observedFields` 필드로 hoist해서 전달하므로, iframe 코드는 storage 키를 알 필요가 없습니다.
+`_` 접두사는 시스템이 관리하는 키임을 표시합니다 — 작성자가 직접 정의한 다른 properties와 겹치지 않도록 별도 네임스페이스를 사용합니다. Walla가 각 참조를 검증한 뒤 `FieldInitPayload`의 타입이 지정된 `observedFields` 필드로 끌어올려 전달하므로, iframe 코드는 저장 키를 알 필요가 없습니다.
 
 스키마는 tagged-union 배열로 선언합니다. `oneOf` 두 분기는 각각 일반 폼 필드(id로 참조)와 hidden 필드(작성자가 정의한 label로 참조)에 해당합니다:
 
@@ -88,12 +88,12 @@ field.onInit(({ properties }) => {
     "_observedFields": {
       "type": "array",
       "title": "관찰할 필드",
-      "description": "이 계산기가 값을 합칠 필드들",
+      "description": "이 계산기가 값을 합칠 필드들.",
       "items": {
         "oneOf": [
           {
             "type": "object",
-            "title": "Regular field reference",
+            "title": "일반 필드 참조",
             "properties": {
               "kind": { "const": "field" },
               "id":   { "type": "string", "title": "필드 id" }
@@ -102,7 +102,7 @@ field.onInit(({ properties }) => {
           },
           {
             "type": "object",
-            "title": "Hidden field reference",
+            "title": "Hidden 필드 참조",
             "properties": {
               "kind":  { "const": "hidden" },
               "label": { "type": "string", "title": "Hidden 필드 라벨" }
@@ -120,13 +120,13 @@ field.onInit(({ properties }) => {
 
 #### 선택 모델
 
-폼 작성자는 authoring 시점에 참조를 선택합니다 — 새로 추가한 필드를 참조하기 위해 먼저 폼을 게시할 필요는 없습니다. 선택된 항목은 작성자가 고른 순서대로 저장되며, `diff`나 list 기반 연산자처럼 순서가 의미 있는 소비자에게 중요합니다.
+폼 작성자는 작성 시점에 참조를 선택합니다 — 새로 추가한 필드를 참조하기 위해 먼저 폼을 게시할 필요는 없습니다. 선택된 항목은 작성자가 고른 순서대로 저장되며, `diff`나 리스트 기반 연산자처럼 순서를 사용하는 곳에서 의미가 있습니다.
 
-이미 사라진 필드(이름이 바뀌어 식별이 깨졌거나, hidden 필드가 제거된 경우)를 가리키는 참조는 런타임에 `formContext`에서 해석되지 않습니다. iframe 코드가 `observedFields`를 순회할 때 모든 ref가 값으로 매핑된다고 가정하지 말고 방어적으로 작성하세요.
+이미 사라진 필드(hidden 필드의 label이 바뀌었거나 일반 필드가 삭제된 경우)를 가리키는 참조는 런타임에 `formContext`에서 해석되지 않습니다. iframe 코드가 `observedFields`를 순회할 때 모든 ref가 값으로 매핑된다고 가정하지 말고 방어적으로 작성하세요.
 
-호스트의 authoring UI는 두 `oneOf` 분기를 그룹으로 나눠 작성자가 JSON을 직접 편집하지 않아도 참조를 선택할 수 있게 해줍니다. 정확한 UI는 host-specific이며, SDK가 의존할 수 있는 계약은 on-the-wire 형태 — 작성자가 고른 순서대로 저장된 `ObservedFieldRef[]` — 입니다.
+호스트의 작성 UI는 두 `oneOf` 분기를 그룹으로 나눠 작성자가 JSON을 직접 편집하지 않아도 참조를 선택할 수 있게 해줍니다. 정확한 UI는 호스트마다 다르며, 보장되는 계약은 전송 형태 — 작성자가 고른 순서대로 저장된 `ObservedFieldRef[]` — 입니다.
 
-#### iframe이 받는 것
+#### iframe이 받는 데이터
 
 버전의 `observeFields.mode`를 `'configured'`로 설정하세요. 작성자가 참조를 선택하면, iframe은 `payload.observedFields`로 참조 목록을, `payload.formContext`로 해석된 값을 받습니다:
 
@@ -137,8 +137,8 @@ field.onInit(({ observedFields, formContext, properties }) => {
   //   { kind: 'field',  id: 'fld_price' },
   //   { kind: 'hidden', label: 'utm_discount' },
   // ]
-  // formContext.fields: 권한 통과한 필드들의 FieldSummary[] (타입 안전)
-  // formContext.values: { [id]: value } — 권한 통과한 부분집합
+  // formContext.fields: 허용된 필드들의 FieldSummary[]
+  // formContext.values: { [id]: value } — 허용된 부분집합
 
   const operands = observedFields.map(ref => {
     if (ref.kind === 'field') return Number(formContext.values[ref.id] ?? 0);
@@ -150,7 +150,7 @@ field.onInit(({ observedFields, formContext, properties }) => {
 });
 ```
 
-> 민감 필드 타입(`SECRETS`, `PHONE_NUMBER`, `EMAIL`)은 `observedFields`에 명시 노출 의도가 있어도 `formContext`에서 항상 제외됩니다. granted 집합은 requested의 strict subset입니다.
+> 민감 필드 타입(`SECRETS`, `PHONE_NUMBER`, `EMAIL`)은 `observedFields`에 명시적으로 포함되어 있어도 `formContext`에서 항상 제외됩니다. 허용된 집합은 항상 요청한 집합의 부분집합입니다.
 
 ## 출력 스키마
 

--- a/content/docs/ko/developer-docs/custom-fields-properties-schema.mdx
+++ b/content/docs/ko/developer-docs/custom-fields-properties-schema.mdx
@@ -118,20 +118,17 @@ field.onInit(({ properties }) => {
 }
 ```
 
-#### Picker UI
+#### 선택 모델
 
-대시보드는 이 정확한 모양(items.oneOf의 분기들이 `kind: 'field' | 'hidden'` discriminator를 가지는 array)을 감지하면, 일반 JSON 에디터 대신 인터랙티브 picker로 swap합니다. picker는 하나의 dropdown 안에서 두 그룹을 보여줍니다:
+폼 작성자는 authoring 시점에 참조를 선택합니다 — 새로 추가한 필드를 참조하기 위해 먼저 폼을 게시할 필요는 없습니다. 선택된 항목은 작성자가 고른 순서대로 저장되며, `diff`나 list 기반 연산자처럼 순서가 의미 있는 소비자에게 중요합니다.
 
-- **Form responses** — 작성자가 추가한 일반 필드들 (폼 순서대로, 타입 배지와 함께)
-- **Query parameters** — 공유/배포 페이지에서 설정한 hidden 필드들
+이미 사라진 필드(이름이 바뀌어 식별이 깨졌거나, hidden 필드가 제거된 경우)를 가리키는 참조는 런타임에 `formContext`에서 해석되지 않습니다. iframe 코드가 `observedFields`를 순회할 때 모든 ref가 값으로 매핑된다고 가정하지 말고 방어적으로 작성하세요.
 
-작성자가 dropdown에서 선택하면 picker 위의 드래그 가능한 레일에 항목이 쌓이며, 저장 시 순서가 보존됩니다 (`diff` 같은 순서-의존 연산자에 의미). 이미 삭제된 필드를 가리키는 참조는 "(deleted)" 표시가 붙어 작성자가 정리할 수 있게 합니다.
-
-picker는 **draft** 폼(편집 중인 YJS 문서)을 읽으므로, 새로 추가하거나 이름을 바꾼 필드도 즉시 dropdown에 나타납니다 — 폼을 게시(publish)하지 않아도 작성자가 바로 참조할 수 있습니다.
+호스트의 authoring UI는 두 `oneOf` 분기를 그룹으로 나눠 작성자가 JSON을 직접 편집하지 않아도 참조를 선택할 수 있게 해줍니다. 정확한 UI는 host-specific이며, SDK가 의존할 수 있는 계약은 on-the-wire 형태 — 작성자가 고른 순서대로 저장된 `ObservedFieldRef[]` — 입니다.
 
 #### iframe이 받는 것
 
-버전의 `observeFields.mode`를 `'configured'`로 설정하세요. 작성자가 picker로 참조를 선택하면, iframe은 `payload.observedFields`로 참조 목록을, `payload.formContext`로 해석된 값을 받습니다:
+버전의 `observeFields.mode`를 `'configured'`로 설정하세요. 작성자가 참조를 선택하면, iframe은 `payload.observedFields`로 참조 목록을, `payload.formContext`로 해석된 값을 받습니다:
 
 ```typescript
 field.onInit(({ observedFields, formContext, properties }) => {

--- a/content/docs/ko/developer-docs/custom-fields-properties-schema.mdx
+++ b/content/docs/ko/developer-docs/custom-fields-properties-schema.mdx
@@ -68,6 +68,93 @@ field.onInit(({ properties }) => {
 }
 ```
 
+### 다른 필드 참조 (`_observedFields`)
+
+수량을 합산하는 계산기, 사용자 선택을 반영하는 가격 미리보기, 이전 답변을 인용하는 요약 — 이런 커스텀 필드는 같은 폼 내 다른 필드의 값이 필요합니다. 시스템 예약 키 `_observedFields`를 properties 스키마에 선언하면, 폼 작성자가 어떤 필드를 관찰할지 직접 선택할 수 있습니다.
+
+`_` 접두사는 시스템 관리 키임을 표시합니다 — 작성자가 직접 정의한 다른 properties와 겹치지 않게 별도 네임스페이스를 차지합니다. Walla가 각 참조를 검증한 뒤 `FieldInitPayload`의 타입 안전한 `observedFields` 필드로 hoist해서 전달하므로, iframe 코드는 storage 키를 알 필요가 없습니다.
+
+스키마는 tagged-union 배열로 선언합니다. `oneOf` 두 분기는 각각 일반 폼 필드(id로 참조)와 hidden 필드(작성자가 정의한 label로 참조)에 해당합니다:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "operator": {
+      "type": "string",
+      "enum": ["sum", "product", "diff", "min", "max", "avg"],
+      "default": "sum"
+    },
+    "_observedFields": {
+      "type": "array",
+      "title": "관찰할 필드",
+      "description": "이 계산기가 값을 합칠 필드들",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "Regular field reference",
+            "properties": {
+              "kind": { "const": "field" },
+              "id":   { "type": "string", "title": "필드 id" }
+            },
+            "required": ["kind", "id"]
+          },
+          {
+            "type": "object",
+            "title": "Hidden field reference",
+            "properties": {
+              "kind":  { "const": "hidden" },
+              "label": { "type": "string", "title": "Hidden 필드 라벨" }
+            },
+            "required": ["kind", "label"]
+          }
+        ]
+      },
+      "default": []
+    }
+  },
+  "required": ["operator"]
+}
+```
+
+#### Picker UI
+
+대시보드는 이 정확한 모양(items.oneOf의 분기들이 `kind: 'field' | 'hidden'` discriminator를 가지는 array)을 감지하면, 일반 JSON 에디터 대신 인터랙티브 picker로 swap합니다. picker는 하나의 dropdown 안에서 두 그룹을 보여줍니다:
+
+- **Form responses** — 작성자가 추가한 일반 필드들 (폼 순서대로, 타입 배지와 함께)
+- **Query parameters** — 공유/배포 페이지에서 설정한 hidden 필드들
+
+작성자가 dropdown에서 선택하면 picker 위의 드래그 가능한 레일에 항목이 쌓이며, 저장 시 순서가 보존됩니다 (`diff` 같은 순서-의존 연산자에 의미). 이미 삭제된 필드를 가리키는 참조는 "(deleted)" 표시가 붙어 작성자가 정리할 수 있게 합니다.
+
+picker는 **draft** 폼(편집 중인 YJS 문서)을 읽으므로, 새로 추가하거나 이름을 바꾼 필드도 즉시 dropdown에 나타납니다 — 폼을 게시(publish)하지 않아도 작성자가 바로 참조할 수 있습니다.
+
+#### iframe이 받는 것
+
+버전의 `observeFields.mode`를 `'configured'`로 설정하세요. 작성자가 picker로 참조를 선택하면, iframe은 `payload.observedFields`로 참조 목록을, `payload.formContext`로 해석된 값을 받습니다:
+
+```typescript
+field.onInit(({ observedFields, formContext, properties }) => {
+  // observedFields: [
+  //   { kind: 'field',  id: 'fld_qty'   },
+  //   { kind: 'field',  id: 'fld_price' },
+  //   { kind: 'hidden', label: 'utm_discount' },
+  // ]
+  // formContext.fields: 권한 통과한 필드들의 FieldSummary[] (타입 안전)
+  // formContext.values: { [id]: value } — 권한 통과한 부분집합
+
+  const operands = observedFields.map(ref => {
+    if (ref.kind === 'field') return Number(formContext.values[ref.id] ?? 0);
+    const f = formContext.fields.find(field => field.label === ref.label);
+    return Number(formContext.values[f?.id ?? ''] ?? 0);
+  });
+
+  field.setValue(operands.reduce((a, b) => a + b, 0));
+});
+```
+
+> 민감 필드 타입(`SECRETS`, `PHONE_NUMBER`, `EMAIL`)은 `observedFields`에 명시 노출 의도가 있어도 `formContext`에서 항상 제외됩니다. granted 집합은 requested의 strict subset입니다.
+
 ## 출력 스키마
 
 `outputSchema`는 필드가 제출 시 생성하는 값의 형식을 정의하는 JSON Schema입니다. Walla는 이 스키마를 다음과 같이 활용합니다:


### PR DESCRIPTION
## Summary

PPRKD-4521 SDK가 도입한 cross-field 참조 protocol과 PPRKD-4554가 추가한 dashboard picker UI에 대한 developer-docs를 추가합니다. SDK README에는 이미 일부 설명이 있지만, walla-docs의 author 관점 reference에 빠져 있어 사용자가 picker 동작 + tagged-union 데이터 흐름 전체를 알 길이 없는 상태였습니다.

3개 토픽 × ko/en = 6 파일 (+312 / -2):

- **properties-schema**: 새 섹션 "Cross-field references (`_observedFields`)" — 시스템 예약 키 컨벤션, tagged-union JSON Schema 예시, **Picker UI** 동작 설명(구조 자동 감지, 두 그룹 dropdown, draft 기반, 드래그 reorder), `payload.observedFields` 사용 예시, 민감 타입 필터링 안내.
- **lifecycle**: "Configured mode" 서브섹션 추가 — `ObservedFieldRef` 모양 + 해석 패턴 (`field.id` vs `hidden.label`). 모드 테이블에서 "admin-selected" → "author-selected" 정정.
- **api-reference**: `FieldInitPayload`에 `observedFields` 추가, `getObservedFields()` 메서드 섹션 추가, `ObservedFieldRef` 타입 섹션 추가.

EN과 KO에 동일하게 반영했고, 코드 펜스 균형/구조 패러렐 확인 완료.

## 변경 파일
- `content/docs/{en,ko}/developer-docs/custom-fields-properties-schema.mdx`
- `content/docs/{en,ko}/developer-docs/custom-fields-lifecycle.mdx`
- `content/docs/{en,ko}/developer-docs/custom-fields-api-reference.mdx`

## 관련 PR
- walla-next [#964 (PPRKD-4521)](https://github.com/teamPaprika/walla-next/pull/964) — cross-field 참조 protocol + calculator example (merged)
- walla-next PPRKD-4554 — picker UI 구현 (현재 작성 중)

## Test plan
- [ ] 로컬 fumadocs dev로 mdx 파싱 확인 (`pnpm dev`)
- [ ] EN/KO 양쪽 페이지에서 새 섹션 렌더링 확인 (헤딩, 코드 블록, 표)
- [ ] 내부 링크 동작 확인 (`./custom-fields-properties-schema` 상호 참조)
- [ ] 모바일/데스크탑에서 표 가독성 확인