### PR TITLE
docs(ko): FAQ 구독·결제 항목 추가 (미사용 환불)

### DIFF
--- a/content/docs/ko/help-center/faq.mdx
+++ b/content/docs/ko/help-center/faq.mdx
@@ -34,6 +34,10 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
     네, 왈라는 무료로 무제한 폼 생성, 무제한 응답 수집, 통계 및 응답 결과 확인이 가능합니다.
   </Accordion>
 
+  <Accordion title="결제 이후 유료 기능을 사용하지 않았는데 환불받을 수 있나요?">
+    왈라는 프로젝트 생성 외에도 설문 링크 공유, 응답 수집, 애널리틱스 확인, 기존 프로젝트에 적용된 유료 기능 유지 등 다양한 형태로 이용이 가능한 서비스입니다. 특히 서비스 특성상 별도의 작업 기록이 남지 않더라도 실제 이용이 이루어질 수 있기 때문에, 내부적으로는 단순 ‘미사용’을 기준으로 이용 여부를 판단하기 어려운 점 양해 부탁드립니다.
+  </Accordion>
+
   <Accordion title="구독을 취소하려면 어떻게 해야 하나요?">
     '팀 설정 → 팀 관리' 페이지에서 `플랜 관리` 버튼을 눌러 결제 정보 페이지로 이동할 수 있고, 이때 `구독 취소` 버튼을 눌러 구독 취소가 가능합니다. 자세한 사항은 [플랜 취소하기](https://docs.walla.my/ko/docs/help-center/getting-started/starting-or-changing-subscription#%ED%94%8C%EB%9E%9C-%EC%B7%A8%EC%86%8C%ED%95%98%EA%B8%B0)를 참고해주세요.
   </Accordion>


### PR DESCRIPTION
## Summary
- FAQ 구독 및 결제 섹션 2번째 자리에 \"결제 이후 유료 기능을 사용하지 않았는데 환불받을 수 있나요?\" 항목 추가

## Test plan
- [x] \`pnpm build\` 통과
- [ ] 배포 후 docs.walla.my/ko/help-center/faq 에서 항목 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)