### PR TITLE
Qualtrics 가이드 제목을 '심플 포맷으로 가져오기'로 변경

### DIFF
--- a/content/docs/ko/help-center/create-forms/importing-from-qualtrics.mdx
+++ b/content/docs/ko/help-center/create-forms/importing-from-qualtrics.mdx
@@ -1,11 +1,11 @@
 ---
-title: Qualtrics에서 가져오기
-description: Qualtrics에서 만든 설문을 왈라로 가져와 그대로 사용할 수 있어요.
+title: Qualtrics 심플 포맷으로 가져오기
+description: Qualtrics 심플 포맷을 따른 .txt 파일을 왈라로 가져와요.
 ---
 
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 
-## Qualtrics 설문 가져오기
+## Qualtrics 심플 포맷으로 가져오기
 
 <Steps>
   <Step>
@@ -15,13 +15,13 @@ import { Step, Steps } from 'fumadocs-ui/components/steps';
     <img src="/images/guides/manage-forms/team-template-create-project.png" alt="워크스페이스 우측 상단의 프로젝트 만들기 버튼" style={{ width: "100%", borderRadius: "8px", marginTop: "12px", marginBottom: "12px", border: "1px solid var(--border)" }} />
   </Step>
   <Step>
-    ### Qualtrics에서 가져오기 선택
-    `Qualtrics에서 가져오기`를 선택합니다.
+    ### Qualtrics 심플 포맷으로 가져오기 선택
+    `Qualtrics 심플 포맷으로 가져오기`를 선택합니다.
 
     <img src="/images/guides/manage-forms/import-qualtrics-select.png" alt="새로운 프로젝트 만들기 팝업에서 Qualtrics에서 가져오기 카드 선택" style={{ width: "100%", borderRadius: "8px", marginTop: "12px", marginBottom: "12px", border: "1px solid var(--border)" }} />
   </Step>
   <Step>
-    ### Qualtrics에서 export한 파일 선택
+    ### 파일 선택
     `찾아보기` 버튼을 눌러 Qualtrics에서 export한 `.txt` 또는 `.docx` 파일을 선택합니다.
 
     <img src="/images/guides/manage-forms/import-qualtrics-file-select.png" alt="Qualtrics에서 가져오기 팝업에서 파일을 선택하면 변환된 문항이 미리보기로 표시되는 화면" style={{ width: "100%", borderRadius: "8px", marginTop: "12px", marginBottom: "12px", border: "1px solid var(--border)" }} />


### PR DESCRIPTION
Qualtrics 가져오기 가이드의 제목과 일부 스텝 제목을 수정했습니다.

- 페이지 제목/설명 및 H2를 "Qualtrics 심플 포맷으로 가져오기"로 변경
- 2번 스텝 제목 변경
- 3번 스텝 제목을 "파일 선택"으로 간소화

🤖 Generated with [Claude Code](https://claude.com/claude-code)