### PR TITLE
docs(responses): response search 엔드포인트 문서 추가 및 parquet 필터 필드 정정 (PPRKD-4723)

### DIFF
--- a/content/docs/en/developer-docs/responses/index.mdx
+++ b/content/docs/en/developer-docs/responses/index.mdx
@@ -211,7 +211,7 @@ The response envelope is identical to [Get Form Responses](#get-form-responses-p
 }
 ```
 
-> **Note**: Fields configured for masking are returned with their keys intact and their values replaced with the string `REDACTED`. The Open API never reveals masked values (the dashboard can, after recording a disclosure reason), and masked fields are not supported as filter values (they always match zero responses). This differs from [Parquet Export](/en/docs/developer-docs/responses/parquet), which omits masked fields entirely.
+> **Note**: Fields configured for masking are returned with their keys intact and their values replaced with the string `REDACTED`. The Open API never reveals masked values (the dashboard can, after recording a disclosure reason), and masked fields are not supported as `responseFields` filter keys. This differs from [Parquet Export](/en/docs/developer-docs/responses/parquet), which omits masked fields entirely.
 
 **Error Responses**
 

--- a/content/docs/en/developer-docs/responses/index.mdx
+++ b/content/docs/en/developer-docs/responses/index.mdx
@@ -211,7 +211,7 @@ The response envelope is identical to [Get Form Responses](#get-form-responses-p
 }
 ```
 
-> **Note**: Fields configured for masking are returned with their values redacted by a regex pattern (e.g. `Jo**`). This matches the behavior of the standard response list, and differs from [Parquet Export](/en/docs/developer-docs/responses/parquet), which omits masked fields entirely.
+> **Note**: Fields configured for masking are returned with their keys intact and their values replaced with the string `REDACTED`. The Open API never reveals masked values (the dashboard can, after recording a disclosure reason), and masked fields are not supported as filter values (they always match zero responses). This differs from [Parquet Export](/en/docs/developer-docs/responses/parquet), which omits masked fields entirely.
 
 **Error Responses**
 

--- a/content/docs/en/developer-docs/responses/index.mdx
+++ b/content/docs/en/developer-docs/responses/index.mdx
@@ -5,7 +5,7 @@ description: API reference for retrieving form responses and submissions
 
 # Form Responses API
 
-The Form Responses API allows you to retrieve and analyze form submissions. You can list all responses with pagination, get detailed response data, and access individual submission information.
+The Form Responses API allows you to retrieve and analyze form submissions. You can list all responses with pagination, search responses with rich filters, get detailed response data, and access individual submission information.
 
 ## Endpoints
 
@@ -31,6 +31,9 @@ GET /open-api/v1/forms/{formId}/responses
 |-----------|------|----------|---------|-------------|
 | `page` | integer | No | 1 | Page number (starts from 1) |
 | `limit` | integer | No | 20 | Number of responses per page (max 100) |
+| `customerKey` | string | No | — | Return only responses with this customerKey |
+
+> **Note**: This endpoint supports a single `customerKey` filter only. For richer filtering — date range, hidden fields, response field values — use the [Search Responses](#search-responses-filtered) endpoint below.
 
 #### Request
 
@@ -100,7 +103,7 @@ curl -X GET "https://api.walla.my/open-api/v1/forms/form_abc/responses?page=2&li
 | `data.pagination` | object | Pagination metadata |
 | `data.pagination.page` | integer | Current page number |
 | `data.pagination.limit` | integer | Responses per page |
-| `data.pagination.totalCount` | integer | Total number of responses |
+| `data.pagination.totalCount` | integer | Exact total number of responses matching the filter |
 | `data.pagination.totalPages` | integer | Total number of pages |
 
 > **Note**: Response objects include dynamic fields based on the form structure. Each form field appears as a property in the response object.
@@ -117,6 +120,118 @@ curl -X GET "https://api.walla.my/open-api/v1/forms/form_abc/responses?page=2&li
 - **403 Forbidden**: Authentication failed or insufficient permissions
 - **404 Not Found**: Form not found
 - **500 Internal Server Error**: Server error
+
+---
+
+### Search Responses (Filtered)
+
+Retrieve a paginated list of responses with rich filters. The response envelope is identical to the paginated list above, but the request takes the **same filter contract** as [Parquet Export](/en/docs/developer-docs/responses/parquet) (customerKeys, submission time range, hidden fields, response fields) in a JSON body. Use this endpoint when the single `customerKey` query filter is not enough and you need nested filters that are awkward to express in a query string.
+
+```http
+POST /open-api/v1/forms/{formId}/responses/search
+```
+
+#### Parameters
+
+**Path Parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `formId` | string | Yes | The unique form identifier |
+
+**Request Body** (all fields optional)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `page` | integer | 1 | Page number (starts from 1) |
+| `limit` | integer | 20 | Number of responses per page (max 100) |
+| `customerKeys` | string[] | — | Return only responses with one of these customerKeys (empty/omitted = all) |
+| `submittedFrom` | string (date-time) | — | Only responses submitted at or after this time. ISO 8601 |
+| `submittedTo` | string (date-time) | — | Only responses submitted at or before this time. ISO 8601 |
+| `hiddenFields` | object | — | Hidden field label → value. Exact match only. Unregistered labels return 400 |
+| `responseFields` | object | — | Response field ID → value (string) or array of values |
+
+> **Note**: If the body is empty, the form's entire response set is returned page by page. Different filters are combined with AND. The per-value-shape interpretation of `responseFields` (single vs. array meaning by field type, unsupported types) is identical to the [response field filter semantics in Parquet Export](/en/docs/developer-docs/responses/parquet#response-field-filter-semantics).
+
+#### Request
+
+**Example Request**
+
+```bash
+# First page of all responses
+curl -X POST "https://api.walla.my/open-api/v1/forms/form_abc/responses/search" \
+  -H "X-WALLA-API-KEY: your_api_key_here" \
+  -H "Content-Type: application/json" \
+  -d '{ "page": 1, "limit": 50 }'
+
+# Filter by date range, customer keys, hidden fields, and response fields
+curl -X POST "https://api.walla.my/open-api/v1/forms/form_abc/responses/search" \
+  -H "X-WALLA-API-KEY: your_api_key_here" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "page": 1,
+    "limit": 50,
+    "submittedFrom": "2024-01-01T00:00:00Z",
+    "submittedTo": "2024-01-31T23:59:59Z",
+    "customerKeys": ["customer_001", "customer_002"],
+    "hiddenFields": { "utm_source": "newsletter" },
+    "responseFields": {
+      "field_score": "5",
+      "field_features": ["Feature A", "Feature B"]
+    }
+  }'
+```
+
+#### Response
+
+**Success Response (200 OK)**
+
+The response envelope is identical to [Get Form Responses](#get-form-responses-paginated). `pagination.totalCount` is the **exact count of all responses matching the filter** (regardless of whether the current page is the last one).
+
+```json
+{
+  "success": true,
+  "data": {
+    "responses": [
+      {
+        "responseId": "response_123",
+        "customerKey": "customer_001",
+        "submittedAt": "2024-01-15T14:30:00Z",
+        "field_score": "5",
+        "field_features": ["Feature A", "Feature B"]
+      }
+    ],
+    "pagination": {
+      "page": 1,
+      "limit": 50,
+      "totalCount": 27,
+      "totalPages": 1
+    }
+  }
+}
+```
+
+> **Note**: Fields configured for masking are returned with their values redacted by a regex pattern (e.g. `Jo**`). This matches the behavior of the standard response list, and differs from [Parquet Export](/en/docs/developer-docs/responses/parquet), which omits masked fields entirely.
+
+**Error Responses**
+
+- **400 Bad Request**: Malformed request body, an unregistered hidden field label, or an unsupported response field. Use `detailsType` to tell the cause apart (`schema` / `unknownHiddenFieldLabel` / `unsupportedResponseField`).
+  ```json
+  {
+    "error": "Unsupported response field",
+    "detailsType": "unsupportedResponseField",
+    "details": [
+      { "fieldId": "field_file", "reason": "unsupported_type", "fieldType": "FILE_UPLOAD" }
+    ]
+  }
+  ```
+- **401 Unauthorized**: Missing or invalid API key
+- **403 Forbidden**: Insufficient permissions (form in another team/workspace)
+- **404 Not Found**: Form not found
+
+<Callout type="info" title="Activity log and PII protection">
+Search requests are recorded in the activity log, but the raw values you pass as filters (such as email addresses or phone numbers) are not retained. Only the field label, `fieldId`, the count of values applied, and whether each filter was used (boolean) are recorded.
+</Callout>
 
 ---
 

--- a/content/docs/en/developer-docs/responses/parquet.mdx
+++ b/content/docs/en/developer-docs/responses/parquet.mdx
@@ -167,7 +167,14 @@ curl -X POST "https://api.walla.my/open-api/v1/forms/form_abc/exports/field-defi
 **Success Response (200 OK)**
 
 - **Content-Type**: `application/vnd.apache.parquet`
-- **Body**: A Parquet file containing the form's field IDs, labels, types, and so on
+- **Body**: A Parquet file containing the form's field definitions. Each row is one field, with the following columns:
+
+| Column | Description |
+|--------|-------------|
+| `fieldId` | The form field ID |
+| `fieldType` | The field type (e.g., `SHORT_TEXT`, `RADIO`) |
+| `label` | The human-readable field label |
+| `columnName` | The column name used in the response export (`f_<fieldId>` form) |
 
 The response data export uses field IDs as column names, so when you need human-readable labels, join the field definitions export on `fieldId` to map them.
 

--- a/content/docs/en/developer-docs/responses/parquet.mdx
+++ b/content/docs/en/developer-docs/responses/parquet.mdx
@@ -109,6 +109,10 @@ curl -X POST "https://api.walla.my/open-api/v1/forms/form_abc/exports/responses"
 
 The response body is a binary Parquet file rather than JSON, so save it to a file with `--output` (or an equivalent option) and read it with a [Parquet tool](#working-with-parquet-files).
 
+<Callout type="info" title="Hidden field values included">
+Submitted values for the form's hidden fields are also included in the response Parquet as `f_hidden-<fieldId>` columns. To resolve their human-readable labels, map them to the `HIDDEN` rows (`fieldId: hidden-<fieldId>`) in the field definitions export.
+</Callout>
+
 **Error Responses**
 
 - **400 Bad Request**: Invalid request body or unsupported response field
@@ -166,6 +170,8 @@ curl -X POST "https://api.walla.my/open-api/v1/forms/form_abc/exports/field-defi
 - **Body**: A Parquet file containing the form's field IDs, labels, types, and so on
 
 The response data export uses field IDs as column names, so when you need human-readable labels, join the field definitions export on `fieldId` to map them.
+
+The form's hidden fields are included as rows with `fieldType` set to `HIDDEN`, where `fieldId` is `hidden-<id>` and `columnName` is `f_hidden-<id>`. These map to the hidden field value columns in the response export.
 
 **Error Responses**
 

--- a/content/docs/en/developer-docs/responses/parquet.mdx
+++ b/content/docs/en/developer-docs/responses/parquet.mdx
@@ -13,7 +13,7 @@ Download form responses and field definitions as [Apache Parquet](https://parque
 
 This API is composed of two export routes:
 
-- **Response data export**: Download response rows as a Parquet file. You can filter by date range, `customerKey`, hidden field values, and response field values.
+- **Response data export**: Download response rows as a Parquet file. You can filter by date range, `customerKeys`, hidden field values, and response field values.
 - **Field definitions export**: Download the form's field definitions as a Parquet file. Use it to map response data column names to their labels and types.
 
 > **Note**: A [rate limit](/en/docs/developer-docs/authentication#rate-limiting) of 6,000 requests per hour per API key applies.
@@ -44,11 +44,11 @@ POST /open-api/v1/forms/{formId}/exports/responses
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `customerKey` | string | No | Filter to responses from a specific customer |
-| `startDate` | string (date-time) | No | Start of the submission time range (ISO 8601) |
-| `endDate` | string (date-time) | No | End of the submission time range (ISO 8601) |
-| `hiddenFields` | object | No | Mapping of hidden field label to value (or array of values) |
-| `responseFields` | object | No | Mapping of response field ID to value (or array of values) |
+| `customerKeys` | string[] | No | Return only responses with one of these customerKeys (empty/omitted = all) |
+| `submittedFrom` | string (date-time) | No | Start of the submission time range, inclusive (ISO 8601) |
+| `submittedTo` | string (date-time) | No | End of the submission time range, inclusive (ISO 8601) |
+| `hiddenFields` | object | No | Mapping of hidden field label to value |
+| `responseFields` | object | No | Mapping of response field ID to value (string) or array of values |
 
 > **Note**: All filters are optional. If you omit every filter, the form's entire response set is exported. Filters within the same object are combined with AND.
 
@@ -61,7 +61,7 @@ Each entry in `responseFields` is interpreted based on the field type and the va
 | Text/number/date-time family (`NUMBER`, `DATE`, `TIME`, `SHORT_TEXT`, `LONG_TEXT`, `EMAIL`, `PHONE_NUMBER`, `ADDRESS`) | Equality match | Equals one of the given values |
 | Choice family (`RADIO`, `DROPDOWN`, `CHECKBOX`, `LINEAR`, `PRIVACY_POLICY_INFORMATION`) | Response array contains the given value | Response array contains any one of the given values |
 
-For example, passing `30` to a `NUMBER` field `field_age` returns only responses where `age = 30`, while passing `[30, 40]` returns responses where `age` is either 30 or 40. Passing `"Feature A"` to a `CHECKBOX` field `field_features` returns only responses whose `features` array contains `"Feature A"`.
+All filter values are passed as strings. For example, passing `"30"` to a `NUMBER` field `field_age` returns only responses where `age = 30`, while passing `["30", "40"]` returns responses where `age` is either 30 or 40. Passing `"Feature A"` to a `CHECKBOX` field `field_features` returns only responses whose `features` array contains `"Feature A"`.
 
 <Callout type="warn" title="Unsupported filter behavior">
 - AND (all-of) semantics across multiple values for a single field is not supported.
@@ -86,13 +86,14 @@ curl -X POST "https://api.walla.my/open-api/v1/forms/form_abc/exports/responses"
   -H "X-WALLA-API-KEY: your_api_key_here" \
   -H "Content-Type: application/json" \
   -d '{
-    "startDate": "2024-01-01T00:00:00Z",
-    "endDate": "2024-01-31T23:59:59Z",
+    "submittedFrom": "2024-01-01T00:00:00Z",
+    "submittedTo": "2024-01-31T23:59:59Z",
+    "customerKeys": ["customer_001", "customer_002"],
     "hiddenFields": {
-      "utm_source": ["google", "naver"]
+      "utm_source": "newsletter"
     },
     "responseFields": {
-      "field_age": [30, 40],
+      "field_age": ["30", "40"],
       "field_features": "Feature A"
     }
   }' \

--- a/content/docs/ko/developer-docs/responses/index.mdx
+++ b/content/docs/ko/developer-docs/responses/index.mdx
@@ -211,7 +211,7 @@ curl -X POST "https://api.walla.my/open-api/v1/forms/form_abc/responses/search" 
 }
 ```
 
-> **참고**: 마스킹이 설정된 필드는 키는 유지되고 값이 문자열 `REDACTED`로 대체되어 반환됩니다. Open API에서는 마스킹 해제를 제공하지 않으며(대시보드는 다운로드 사유 기록 후 마스킹 값 열람 가능), 마스킹 필드를 필터 값으로 사용하는 것도 지원하지 않습니다(항상 0건 매칭). 마스킹 필드를 통째로 제외하는 [Parquet 내보내기](/ko/docs/developer-docs/responses/parquet)와는 처리 방식이 다릅니다.
+> **참고**: 마스킹이 설정된 필드는 키는 유지되고 값이 문자열 `REDACTED`로 대체되어 반환됩니다. Open API에서는 마스킹 해제를 제공하지 않으며(대시보드는 다운로드 사유 기록 후 마스킹 값 열람 가능), 마스킹 필드를 `responseFields` 필터로 사용하는 것은 지원되지 않습니다. 마스킹 필드를 통째로 제외하는 [Parquet 내보내기](/ko/docs/developer-docs/responses/parquet)와는 처리 방식이 다릅니다.
 
 **오류 응답**
 

--- a/content/docs/ko/developer-docs/responses/index.mdx
+++ b/content/docs/ko/developer-docs/responses/index.mdx
@@ -211,7 +211,7 @@ curl -X POST "https://api.walla.my/open-api/v1/forms/form_abc/responses/search" 
 }
 ```
 
-> **참고**: 마스킹이 설정된 필드는 응답 값이 정규식으로 가려진 상태(예: `홍**`)로 반환됩니다. 이는 기존 응답 목록과 동일한 동작으로, 마스킹 필드를 통째로 제외하는 [Parquet 내보내기](/ko/docs/developer-docs/responses/parquet)와는 다릅니다.
+> **참고**: 마스킹이 설정된 필드는 키는 유지되고 값이 문자열 `REDACTED`로 대체되어 반환됩니다. Open API에서는 마스킹 해제를 제공하지 않으며(대시보드는 다운로드 사유 기록 후 마스킹 값 열람 가능), 마스킹 필드를 필터 값으로 사용하는 것도 지원하지 않습니다(항상 0건 매칭). 마스킹 필드를 통째로 제외하는 [Parquet 내보내기](/ko/docs/developer-docs/responses/parquet)와는 처리 방식이 다릅니다.
 
 **오류 응답**
 

--- a/content/docs/ko/developer-docs/responses/index.mdx
+++ b/content/docs/ko/developer-docs/responses/index.mdx
@@ -5,7 +5,7 @@ description: 폼 응답 및 제출 데이터를 조회하기 위한 API 레퍼�
 
 # 폼 응답 API
 
-폼 응답 API로 폼 제출 데이터를 조회하고 분석할 수 있습니다. 페이지네이션을 지원하며, 전체 응답 목록 조회와 개별 응답 상세 조회가 가능합니다.
+폼 응답 API로 폼 제출 데이터를 조회하고 분석할 수 있습니다. 페이지네이션을 지원하며, 전체 응답 목록 조회, 필터를 적용한 응답 검색, 개별 응답 상세 조회가 가능합니다.
 
 ## 엔드포인트
 
@@ -31,6 +31,9 @@ GET /open-api/v1/forms/{formId}/responses
 |-----------|------|----------|---------|-------------|
 | `page` | integer | 아니오 | 1 | 페이지 번호 (1부터 시작) |
 | `limit` | integer | 아니오 | 20 | 페이지당 응답 수 (최대 100) |
+| `customerKey` | string | 아니오 | — | 특정 customerKey를 가진 응답만 조회 |
+
+> **참고**: 이 엔드포인트는 단일 `customerKey` 필터만 지원합니다. 기간·히든 필드·응답 필드 값 등 더 풍부한 필터가 필요하면 아래 [응답 검색](#응답-검색-필터) 엔드포인트를 사용하세요.
 
 #### 요청
 
@@ -100,7 +103,7 @@ curl -X GET "https://api.walla.my/open-api/v1/forms/form_abc/responses?page=2&li
 | `data.pagination` | object | 페이지네이션 메타데이터 |
 | `data.pagination.page` | integer | 현재 페이지 번호 |
 | `data.pagination.limit` | integer | 페이지당 응답 수 |
-| `data.pagination.totalCount` | integer | 전체 응답 수 |
+| `data.pagination.totalCount` | integer | 필터를 적용한 전체 응답의 정확한 개수 |
 | `data.pagination.totalPages` | integer | 전체 페이지 수 |
 
 > **참고**: 응답 객체에는 폼 구조에 따른 동적 필드가 포함됩니다. 각 폼 필드의 ID가 키로, 필드 타입에 따른 값이 동적으로 들어갑니다. 필드 타입별 출력 형식은 [필드 출력 스키마](/ko/docs/developer-docs/field-schemas) 문서를 참고하세요.
@@ -117,6 +120,118 @@ curl -X GET "https://api.walla.my/open-api/v1/forms/form_abc/responses?page=2&li
 - **403 Forbidden**: 인증 실패 또는 권한 부족
 - **404 Not Found**: 폼을 찾을 수 없음
 - **500 Internal Server Error**: 서버 오류
+
+---
+
+### 응답 검색 (필터)
+
+응답 목록을 풍부한 필터와 함께 조회합니다. 응답 형식은 위의 페이지네이션 목록과 동일하지만, [Parquet 내보내기](/ko/docs/developer-docs/responses/parquet)와 **동일한 필터 계약**(customerKeys, 제출일시 범위, 히든 필드, 응답 필드)을 JSON 본문으로 받습니다. 쿼리 스트링으로 표현하기 어려운 중첩 필터를 다룰 수 있어, 단일 `customerKey` 필터만으로 부족할 때 사용합니다.
+
+```http
+POST /open-api/v1/forms/{formId}/responses/search
+```
+
+#### 파라미터
+
+**경로 파라미터**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|-----------|------|----------|-------------|
+| `formId` | string | 예 | 고유한 폼 식별자 |
+
+**요청 본문** (모든 필드 선택)
+
+| 필드 | 타입 | 기본값 | 설명 |
+|------|------|---------|-------------|
+| `page` | integer | 1 | 페이지 번호 (1부터 시작) |
+| `limit` | integer | 20 | 페이지당 응답 수 (최대 100) |
+| `customerKeys` | string[] | — | 지정한 customerKey를 가진 응답만 포함. 빈 배열이거나 생략하면 전체 |
+| `submittedFrom` | string (date-time) | — | 이 시각 이후(이 시각 포함)에 제출된 응답만. ISO 8601 |
+| `submittedTo` | string (date-time) | — | 이 시각 이전(이 시각 포함)에 제출된 응답만. ISO 8601 |
+| `hiddenFields` | object | — | 히든 필드 라벨 → 값. 정확히 일치하는 응답만. 등록되지 않은 라벨은 400 |
+| `responseFields` | object | — | 응답 필드 ID → 값(문자열) 또는 값 배열 |
+
+> **참고**: 본문이 비어 있으면 폼의 전체 응답을 페이지 단위로 반환합니다. 서로 다른 필터는 AND로 결합됩니다. `responseFields`의 값 형태별 해석(필드 타입에 따른 단일/배열 값 의미, 미지원 타입)은 [Parquet 내보내기의 응답 필드 필터 의미론](/ko/docs/developer-docs/responses/parquet#응답-필드-필터-의미론)과 동일합니다.
+
+#### 요청
+
+**요청 예시**
+
+```bash
+# 전체 응답 첫 페이지
+curl -X POST "https://api.walla.my/open-api/v1/forms/form_abc/responses/search" \
+  -H "X-WALLA-API-KEY: your_api_key_here" \
+  -H "Content-Type: application/json" \
+  -d '{ "page": 1, "limit": 50 }'
+
+# 기간 + 고객 키 + 히든 필드 + 응답 필드 필터
+curl -X POST "https://api.walla.my/open-api/v1/forms/form_abc/responses/search" \
+  -H "X-WALLA-API-KEY: your_api_key_here" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "page": 1,
+    "limit": 50,
+    "submittedFrom": "2024-01-01T00:00:00Z",
+    "submittedTo": "2024-01-31T23:59:59Z",
+    "customerKeys": ["customer_001", "customer_002"],
+    "hiddenFields": { "utm_source": "newsletter" },
+    "responseFields": {
+      "field_score": "5",
+      "field_features": ["Feature A", "Feature B"]
+    }
+  }'
+```
+
+#### 응답
+
+**성공 응답 (200 OK)**
+
+응답 형식은 [폼 응답 조회](#폼-응답-조회-페이지네이션)와 동일합니다. `pagination.totalCount`는 **필터를 적용한 전체 응답의 정확한 개수**입니다(현재 페이지가 마지막인지와 무관).
+
+```json
+{
+  "success": true,
+  "data": {
+    "responses": [
+      {
+        "responseId": "response_123",
+        "customerKey": "customer_001",
+        "submittedAt": "2024-01-15T14:30:00Z",
+        "field_score": "5",
+        "field_features": ["Feature A", "Feature B"]
+      }
+    ],
+    "pagination": {
+      "page": 1,
+      "limit": 50,
+      "totalCount": 27,
+      "totalPages": 1
+    }
+  }
+}
+```
+
+> **참고**: 마스킹이 설정된 필드는 응답 값이 정규식으로 가려진 상태(예: `홍**`)로 반환됩니다. 이는 기존 응답 목록과 동일한 동작으로, 마스킹 필드를 통째로 제외하는 [Parquet 내보내기](/ko/docs/developer-docs/responses/parquet)와는 다릅니다.
+
+**오류 응답**
+
+- **400 Bad Request**: 요청 본문 형식 위반, 등록되지 않은 히든 필드 라벨, 또는 미지원 응답 필드. `detailsType`으로 원인을 구분합니다 (`schema` / `unknownHiddenFieldLabel` / `unsupportedResponseField`).
+  ```json
+  {
+    "error": "Unsupported response field",
+    "detailsType": "unsupportedResponseField",
+    "details": [
+      { "fieldId": "field_file", "reason": "unsupported_type", "fieldType": "FILE_UPLOAD" }
+    ]
+  }
+  ```
+- **401 Unauthorized**: API 키 누락 또는 유효하지 않음
+- **403 Forbidden**: 권한 없음 (다른 팀/워크스페이스의 폼)
+- **404 Not Found**: 폼을 찾을 수 없음
+
+<Callout type="info" title="활동 로그와 PII 보호">
+응답 검색 요청은 활동 로그에 기록되지만, 필터로 전달한 raw 값(이메일 주소, 전화번호 등)은 로그에 남지 않습니다. 필드 라벨, `fieldId`, 적용된 값의 개수, 필터 사용 여부(boolean)만 기록됩니다.
+</Callout>
 
 ---
 

--- a/content/docs/ko/developer-docs/responses/parquet.mdx
+++ b/content/docs/ko/developer-docs/responses/parquet.mdx
@@ -13,7 +13,7 @@ description: 폼 응답과 필드 정의를 Apache Parquet 파일로 스트리�
 
 이 API는 두 종류의 export 라우트로 구성됩니다.
 
-- **응답 데이터 export**: 응답 행을 Parquet 파일로 내려받습니다. 기간, `customerKey`, 히든 필드 값, 응답 필드 값으로 필터링할 수 있습니다.
+- **응답 데이터 export**: 응답 행을 Parquet 파일로 내려받습니다. 기간, `customerKeys`, 히든 필드 값, 응답 필드 값으로 필터링할 수 있습니다.
 - **필드 정의 export**: 폼의 필드 정의를 Parquet 파일로 내려받습니다. 응답 데이터의 컬럼명과 라벨/타입을 매핑할 때 사용합니다.
 
 > **참고**: API 키당 시간당 6,000건의 [속도 제한](/ko/docs/developer-docs/authentication#속도-제한)이 적용됩니다.
@@ -44,11 +44,11 @@ POST /open-api/v1/forms/{formId}/exports/responses
 
 | 필드 | 타입 | 필수 여부 | 설명 |
 |------|------|----------|------|
-| `customerKey` | string | 아니오 | 특정 고객의 응답만 필터링 |
-| `startDate` | string (date-time) | 아니오 | 제출 시각의 시작 범위 (ISO 8601) |
-| `endDate` | string (date-time) | 아니오 | 제출 시각의 종료 범위 (ISO 8601) |
-| `hiddenFields` | object | 아니오 | 히든 필드 라벨 → 값(또는 값 배열) 매핑 |
-| `responseFields` | object | 아니오 | 응답 필드 ID → 값(또는 값 배열) 매핑 |
+| `customerKeys` | string[] | 아니오 | 지정한 customerKey를 가진 응답만 필터링 (빈 배열·생략 시 전체) |
+| `submittedFrom` | string (date-time) | 아니오 | 제출 시각의 시작 범위, 이 시각 포함 (ISO 8601) |
+| `submittedTo` | string (date-time) | 아니오 | 제출 시각의 종료 범위, 이 시각 포함 (ISO 8601) |
+| `hiddenFields` | object | 아니오 | 히든 필드 라벨 → 값 매핑 |
+| `responseFields` | object | 아니오 | 응답 필드 ID → 값(문자열) 또는 값 배열 매핑 |
 
 > **참고**: 모든 필터는 선택입니다. 모든 필터를 생략하면 폼의 전체 응답이 export 됩니다. 동일한 객체 안의 필터는 AND 로 결합됩니다.
 
@@ -61,7 +61,7 @@ POST /open-api/v1/forms/{formId}/exports/responses
 | 텍스트/숫자/일시 계열 (`NUMBER`, `DATE`, `TIME`, `SHORT_TEXT`, `LONG_TEXT`, `EMAIL`, `PHONE_NUMBER`, `ADDRESS`) | 같음 비교 | 주어진 값 중 하나와 같음 |
 | 선택형 (`RADIO`, `DROPDOWN`, `CHECKBOX`, `LINEAR`, `PRIVACY_POLICY_INFORMATION`) | 응답 배열에 해당 값이 포함됨 | 응답 배열이 주어진 값 중 하나라도 포함함 |
 
-예를 들어 `NUMBER` 필드 `field_age` 에 `30` 을 전달하면 `age = 30` 인 응답만, `[30, 40]` 을 전달하면 `age` 가 30 또는 40 인 응답이 반환됩니다. `CHECKBOX` 필드 `field_features` 에 `"Feature A"` 를 전달하면 `features` 배열에 `"Feature A"` 가 포함된 응답만 반환됩니다.
+필터 값은 모두 문자열로 전달합니다. 예를 들어 `NUMBER` 필드 `field_age` 에 `"30"` 을 전달하면 `age = 30` 인 응답만, `["30", "40"]` 을 전달하면 `age` 가 30 또는 40 인 응답이 반환됩니다. `CHECKBOX` 필드 `field_features` 에 `"Feature A"` 를 전달하면 `features` 배열에 `"Feature A"` 가 포함된 응답만 반환됩니다.
 
 <Callout type="warn" title="미지원 필터 동작">
 - 단일 필드 안에서 여러 값을 모두 만족시키는 AND(all-of) 의미는 지원하지 않습니다.
@@ -86,13 +86,14 @@ curl -X POST "https://api.walla.my/open-api/v1/forms/form_abc/exports/responses"
   -H "X-WALLA-API-KEY: your_api_key_here" \
   -H "Content-Type: application/json" \
   -d '{
-    "startDate": "2024-01-01T00:00:00Z",
-    "endDate": "2024-01-31T23:59:59Z",
+    "submittedFrom": "2024-01-01T00:00:00Z",
+    "submittedTo": "2024-01-31T23:59:59Z",
+    "customerKeys": ["customer_001", "customer_002"],
     "hiddenFields": {
-      "utm_source": ["google", "naver"]
+      "utm_source": "newsletter"
     },
     "responseFields": {
-      "field_age": [30, 40],
+      "field_age": ["30", "40"],
       "field_features": "Feature A"
     }
   }' \

--- a/content/docs/ko/developer-docs/responses/parquet.mdx
+++ b/content/docs/ko/developer-docs/responses/parquet.mdx
@@ -167,7 +167,14 @@ curl -X POST "https://api.walla.my/open-api/v1/forms/form_abc/exports/field-defi
 **성공 응답 (200 OK)**
 
 - **Content-Type**: `application/vnd.apache.parquet`
-- **본문**: 폼의 필드 ID, 라벨, 타입 등이 담긴 Parquet 파일
+- **본문**: 폼의 필드 정의가 담긴 Parquet 파일. 각 행이 하나의 필드이며 다음 컬럼을 포함합니다.
+
+| 컬럼 | 설명 |
+|------|------|
+| `fieldId` | 폼 필드 ID |
+| `fieldType` | 필드 타입 (예: `SHORT_TEXT`, `RADIO`) |
+| `label` | 사람이 읽을 수 있는 필드 라벨 |
+| `columnName` | 응답 export 에서 사용하는 컬럼명 (`f_<fieldId>` 형태) |
 
 응답 데이터 export 의 컬럼은 필드 ID 로 표기되므로, 사람이 읽을 수 있는 라벨이 필요할 때는 필드 정의 export 의 결과와 `fieldId` 기준으로 join 하여 매핑하세요.
 

--- a/content/docs/ko/developer-docs/responses/parquet.mdx
+++ b/content/docs/ko/developer-docs/responses/parquet.mdx
@@ -109,6 +109,10 @@ curl -X POST "https://api.walla.my/open-api/v1/forms/form_abc/exports/responses"
 
 응답 본문은 JSON 이 아닌 바이너리 Parquet 파일이므로, `--output` 또는 동등한 옵션으로 파일에 저장한 뒤 [Parquet 도구](#parquet-파일-사용-안내)로 읽어야 합니다.
 
+<Callout type="info" title="히든 필드 값 포함">
+폼에 설정된 히든 필드의 제출 값도 응답 Parquet 에 `f_hidden-<fieldId>` 컬럼으로 함께 포함됩니다. 사람이 읽을 수 있는 라벨은 필드 정의 export 의 `HIDDEN` 행(`fieldId: hidden-<fieldId>`)과 매핑해 확인하세요.
+</Callout>
+
 **오류 응답**
 
 - **400 Bad Request**: 잘못된 요청 본문 또는 미지원 응답 필드
@@ -166,6 +170,8 @@ curl -X POST "https://api.walla.my/open-api/v1/forms/form_abc/exports/field-defi
 - **본문**: 폼의 필드 ID, 라벨, 타입 등이 담긴 Parquet 파일
 
 응답 데이터 export 의 컬럼은 필드 ID 로 표기되므로, 사람이 읽을 수 있는 라벨이 필요할 때는 필드 정의 export 의 결과와 `fieldId` 기준으로 join 하여 매핑하세요.
+
+폼에 설정된 히든 필드도 행으로 포함되며, `fieldType` 은 `HIDDEN`, `fieldId` 는 `hidden-<id>`, `columnName` 은 `f_hidden-<id>` 입니다. 응답 export 의 히든 필드 값 컬럼과 매핑됩니다.
 
 **오류 응답**
 

--- a/swagger.json
+++ b/swagger.json
@@ -2044,7 +2044,7 @@
     },
     "/open-api/v1/forms/{formId}/responses": {
       "get": {
-        "description": "본인이 권한을 가진 특정 폼(프로젝트)의 응답 목록을 페이지네이션하여 조회합니다.\n\n**customerKey 필터링**: `customerKey` 파라미터를 사용하여 특정 고객의 응답만 조회할 수 있습니다.\n\n**응답 데이터 구조**: 각 응답 객체는 폼 필드들의 값을 동적 속성으로 포함합니다. 필드 ID가 키이고, 값의 타입은 필드 타입에 따라 다릅니다.\n\n필드 타입별 응답 값 형식을 이해하려면 다음 엔드포인트를 참조하세요:\n- `GET /open-api/v1/field-output-schemas` - 필드 타입별 출력 스키마 매핑\n- `GET /open-api/v1/forms/{formId}/fields` - 해당 폼의 필드 목록 및 출력 타입\n",
+        "description": "본인이 권한을 가진 특정 폼(프로젝트)의 응답 목록을 페이지네이션하여 조회합니다.\n\n**customerKey 필터링**: `customerKey` 파라미터를 사용하여 특정 고객의 응답만 조회할 수 있습니다.\n\n**응답 데이터 구조**: 각 응답 객체는 폼 필드들의 값을 동적 속성으로 포함합니다. 필드 ID가 키이고, 값의 타입은 필드 타입에 따라 다릅니다.\n\n**마스킹 필드**: 응답 마스킹이 설정된 필드는 키는 유지되고 값이 문자열 `REDACTED`로 대체되어 반환됩니다. Open API에서는 마스킹 해제를 제공하지 않습니다.\n\n필드 타입별 응답 값 형식을 이해하려면 다음 엔드포인트를 참조하세요:\n- `GET /open-api/v1/field-output-schemas` - 필드 타입별 출력 스키마 매핑\n- `GET /open-api/v1/forms/{formId}/fields` - 해당 폼의 필드 목록 및 출력 타입\n",
         "security": [
           {
             "ApiKeyAuth": []
@@ -2236,7 +2236,7 @@
     },
     "/open-api/v1/forms/{formId}/responses/search": {
       "post": {
-        "description": "제출된 응답 목록을 풍부한 필터와 함께 페이지네이션하여 조회합니다. `GET /open-api/v1/forms/{formId}/responses`와 동일한 응답 envelope을 반환하지만, parquet export(`POST .../exports/responses`)와 동일한 필터 계약(customerKeys, 제출일시 범위, hidden field, response field Tier A/B)을 본문으로 받습니다.\n\n**응답 데이터 구조**: 각 응답 객체는 폼 필드들의 값을 동적 속성으로 포함합니다. 필드 ID가 키이고, 값의 타입은 필드 타입에 따라 다릅니다. 필드 타입별 출력 형식은 `GET /open-api/v1/forms/{formId}/fields`로 조회하세요.\n\n**모든 필터는 선택**입니다. 본문이 비어 있으면 폼의 전체 제출 응답을 페이지 단위로 반환합니다. 둘 이상의 필터를 함께 보내면 모두 만족하는(AND) 응답만 포함됩니다.\n\n**pagination.totalCount는 필터를 적용한 전체 응답의 정확한 개수**입니다(현재 페이지가 마지막인지와 무관하게 COUNT(*) 기반 정확값).\n",
+        "description": "제출된 응답 목록을 풍부한 필터와 함께 페이지네이션하여 조회합니다. `GET /open-api/v1/forms/{formId}/responses`와 동일한 응답 envelope을 반환하지만, parquet export(`POST .../exports/responses`)와 동일한 필터 계약(customerKeys, 제출일시 범위, hidden field, response field Tier A/B)을 본문으로 받습니다.\n\n**응답 데이터 구조**: 각 응답 객체는 폼 필드들의 값을 동적 속성으로 포함합니다. 필드 ID가 키이고, 값의 타입은 필드 타입에 따라 다릅니다. 필드 타입별 출력 형식은 `GET /open-api/v1/forms/{formId}/fields`로 조회하세요.\n\n**모든 필터는 선택**입니다. 본문이 비어 있으면 폼의 전체 제출 응답을 페이지 단위로 반환합니다. 둘 이상의 필터를 함께 보내면 모두 만족하는(AND) 응답만 포함됩니다.\n\n**마스킹 필드**: 응답 마스킹이 설정된 필드는 키는 유지되고 값이 문자열 `REDACTED`로 대체되어 반환됩니다. Open API에서는 마스킹 해제를 제공하지 않으며, 마스킹 필드를 필터 값으로 사용하는 것도 지원하지 않습니다(항상 0건 매칭).\n\n**pagination.totalCount는 필터를 적용한 전체 응답의 정확한 개수**입니다(현재 페이지가 마지막인지와 무관하게 COUNT(*) 기반 정확값).\n",
         "security": [
           {
             "ApiKeyAuth": []

--- a/swagger.json
+++ b/swagger.json
@@ -160,8 +160,8 @@
               }
             }
           },
-          "403": {
-            "description": "인증 실패",
+          "401": {
+            "description": "인증 실패 (X-WALLA-API-KEY 헤더 누락 또는 유효하지 않음)",
             "content": {
               "application/json": {
                 "schema": {
@@ -1098,8 +1098,23 @@
               }
             }
           },
+          "401": {
+            "description": "인증 실패 (X-WALLA-API-KEY 헤더 누락 또는 유효하지 않음)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
-            "description": "인증 실패 또는 권한 없음",
+            "description": "권한 없음",
             "content": {
               "application/json": {
                 "schema": {
@@ -1266,8 +1281,23 @@
               }
             }
           },
+          "401": {
+            "description": "인증 실패 (X-WALLA-API-KEY 헤더 누락 또는 유효하지 않음)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
-            "description": "인증 실패 또는 권한 없음",
+            "description": "권한 없음",
             "content": {
               "application/json": {
                 "schema": {
@@ -1394,8 +1424,23 @@
               }
             }
           },
+          "401": {
+            "description": "인증 실패 (X-WALLA-API-KEY 헤더 누락 또는 유효하지 않음)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
-            "description": "인증 실패 또는 권한 없음",
+            "description": "권한 없음",
             "content": {
               "application/json": {
                 "schema": {
@@ -1934,8 +1979,23 @@
               }
             }
           },
+          "401": {
+            "description": "인증 실패 (X-WALLA-API-KEY 헤더 누락 또는 유효하지 않음)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
-            "description": "인증 실패 또는 권한 없음",
+            "description": "권한 없음",
             "content": {
               "application/json": {
                 "schema": {
@@ -2111,8 +2171,23 @@
               }
             }
           },
+          "401": {
+            "description": "인증 실패 (X-WALLA-API-KEY 헤더 누락 또는 유효하지 않음)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
-            "description": "인증 실패 또는 권한 없음",
+            "description": "권한 없음",
             "content": {
               "application/json": {
                 "schema": {
@@ -2155,6 +2230,235 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/open-api/v1/forms/{formId}/responses/search": {
+      "post": {
+        "description": "제출된 응답 목록을 풍부한 필터와 함께 페이지네이션하여 조회합니다. `GET /open-api/v1/forms/{formId}/responses`와 동일한 응답 envelope을 반환하지만, parquet export(`POST .../exports/responses`)와 동일한 필터 계약(customerKeys, 제출일시 범위, hidden field, response field Tier A/B)을 본문으로 받습니다.\n\n**응답 데이터 구조**: 각 응답 객체는 폼 필드들의 값을 동적 속성으로 포함합니다. 필드 ID가 키이고, 값의 타입은 필드 타입에 따라 다릅니다. 필드 타입별 출력 형식은 `GET /open-api/v1/forms/{formId}/fields`로 조회하세요.\n\n**모든 필터는 선택**입니다. 본문이 비어 있으면 폼의 전체 제출 응답을 페이지 단위로 반환합니다. 둘 이상의 필터를 함께 보내면 모두 만족하는(AND) 응답만 포함됩니다.\n\n**pagination.totalCount는 필터를 적용한 전체 응답의 정확한 개수**입니다(현재 페이지가 마지막인지와 무관하게 COUNT(*) 기반 정확값).\n",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "formId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "폼 ID"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "page": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 1,
+                    "description": "페이지 번호 (1부터 시작)"
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 20,
+                    "description": "페이지당 응답 개수 (최대 100)"
+                  },
+                  "customerKeys": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "지정한 customerKey를 가진 응답만 포함합니다. 빈 배열이거나 생략하면 모든 응답이 포함됩니다.",
+                    "example": [
+                      "cust_abc",
+                      "cust_def"
+                    ]
+                  },
+                  "submittedFrom": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "이 시각 이후(이 시각 포함)에 제출된 응답만 포함합니다. ISO 8601 / RFC 3339.",
+                    "example": "2026-04-01T00:00:00Z"
+                  },
+                  "submittedTo": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "이 시각 이전(이 시각 포함)에 제출된 응답만 포함합니다. ISO 8601 / RFC 3339.",
+                    "example": "2026-04-30T23:59:59Z"
+                  },
+                  "hiddenFields": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "주어진 hidden field 값과 정확히 일치하는 응답만 포함합니다. 키는 hidden field의 라벨(`POST /open-api/v1/forms/{formId}/hidden-fields`로 등록한 그 라벨)입니다. 둘 이상의 라벨을 보내면 모두 일치(AND)해야 합니다. 등록되지 않은 라벨을 보내면 400을 반환합니다.\n",
+                    "example": {
+                      "utm_source": "newsletter",
+                      "utm_campaign": "spring_2026"
+                    }
+                  },
+                  "responseFields": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1
+                        }
+                      ]
+                    },
+                    "description": "폼 필드의 제출 값으로 응답을 필터링합니다. 키는 fieldId입니다(폼의 fieldId와 타입 목록은 `GET /open-api/v1/forms/{formId}/fields`로 조회).\n\n값은 단일 문자열 또는 문자열 배열로 보낼 수 있고, 필드 타입에 따라 의미가 달라집니다.\n\n**텍스트/숫자/일시 계열 필드** — `NUMBER`, `DATE`, `TIME`, `SHORT_TEXT`, `LONG_TEXT`, `EMAIL`, `PHONE_NUMBER`, `ADDRESS`:\n- 단일 값: 응답 값이 해당 값과 정확히 일치\n- 배열 값: 응답 값이 배열 중 하나와 일치 (OR)\n\n**선택형 필드** — `RADIO`, `DROPDOWN`, `CHECKBOX`, `LINEAR`, `PRIVACY_POLICY_INFORMATION`:\n- 단일 값: 응답 선택지에 해당 값이 포함됨\n- 배열 값: 응답 선택지가 배열 중 하나라도 포함 (OR)\n\n서로 다른 fieldId끼리는 AND로 묶입니다. 한 필드 안에서 \"여러 값을 모두 선택\"(AND) 의미는 현재 지원하지 않습니다.\n\n필터링이 지원되지 않는 타입(HIDDEN, 파일 업로드, 그리드, 구조화 객체, 커스텀, 입력 없음 필드)을 키로 보내면 400 + `detailsType: \"unsupportedResponseField\"`를 반환합니다. HIDDEN 필드는 위의 `hiddenFields` 필터를 사용하세요.\n",
+                    "example": {
+                      "field_score": "5",
+                      "field_email": [
+                        "a@example.com",
+                        "b@example.com"
+                      ],
+                      "field_choice": "Yes",
+                      "field_options": [
+                        "식품",
+                        "여행"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "응답 목록 조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "responses": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "responseId": {
+                                "type": "string",
+                                "description": "응답 ID"
+                              },
+                              "customerKey": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "고객 키"
+                              },
+                              "submittedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "제출일시"
+                              }
+                            },
+                            "additionalProperties": true,
+                            "description": "응답 데이터 (폼 필드값들이 동적으로 포함됨)"
+                          }
+                        },
+                        "pagination": {
+                          "type": "object",
+                          "properties": {
+                            "page": {
+                              "type": "integer",
+                              "description": "현재 페이지 번호"
+                            },
+                            "limit": {
+                              "type": "integer",
+                              "description": "페이지당 응답 개수"
+                            },
+                            "totalCount": {
+                              "type": "integer",
+                              "description": "필터를 적용한 전체 응답 개수 (정확값)"
+                            },
+                            "totalPages": {
+                              "type": "integer",
+                              "description": "전체 페이지 수"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "잘못된 요청 (요청 본문 형식 위반, 등록되지 않은 hidden field 라벨, 지원되지 않는 응답 필드, 또는 submittedFrom > submittedTo)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "오류 코드"
+                    },
+                    "detailsType": {
+                      "type": "string",
+                      "enum": [
+                        "schema",
+                        "unknownHiddenFieldLabel",
+                        "unsupportedResponseField"
+                      ],
+                      "description": "`details` 배열의 스키마를 구분합니다.\n- `schema`: 요청 본문이 기대 형식과 다름. `details[i] = { path, message }`\n- `unknownHiddenFieldLabel`: `hiddenFields`의 키가 폼에 등록되지 않음. `details[i] = { label }`\n- `unsupportedResponseField`: `responseFields`의 키가 폼에 없거나 필터 불가 타입. `details[i] = { fieldId, reason: \"not_found\" | \"unsupported_type\", fieldType? }`\n"
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "사람이 읽을 수 있는 추가 설명 (라벨/타입 목록 등)"
+                    },
+                    "details": {
+                      "type": "array",
+                      "description": "위반 항목 목록. detailsType에 따라 형태가 달라집니다.",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "supportedFieldIds": {
+                      "type": "object",
+                      "description": "detailsType=unsupportedResponseField일 때만 존재. 폼에서 필터링 가능한 fieldId를 그룹별로 안내합니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증 실패 (X-WALLA-API-KEY 헤더 누락 또는 유효하지 않음)"
+          },
+          "403": {
+            "description": "권한 없음 (다른 팀/워크스페이스의 폼 또는 워크스페이스 멤버 아님)"
+          },
+          "404": {
+            "description": "폼이 없거나 게시되지 않음"
+          },
+          "502": {
+            "description": "응답 조회 서비스 일시적으로 불가. 잠시 후 재시도해주세요."
           }
         }
       }
@@ -2245,8 +2549,23 @@
               }
             }
           },
+          "401": {
+            "description": "인증 실패 (X-WALLA-API-KEY 헤더 누락 또는 유효하지 않음)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
-            "description": "인증 실패 또는 권한 없음",
+            "description": "권한 없음",
             "content": {
               "application/json": {
                 "schema": {
@@ -2405,8 +2724,23 @@
               }
             }
           },
+          "401": {
+            "description": "인증 실패 (X-WALLA-API-KEY 헤더 누락 또는 유효하지 않음)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
-            "description": "인증 실패 또는 권한 없음",
+            "description": "권한 없음",
             "content": {
               "application/json": {
                 "schema": {
@@ -2545,8 +2879,23 @@
               }
             }
           },
+          "401": {
+            "description": "인증 실패 (X-WALLA-API-KEY 헤더 누락 또는 유효하지 않음)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
-            "description": "인증 실패 또는 권한 없음",
+            "description": "권한 없음",
             "content": {
               "application/json": {
                 "schema": {
@@ -2655,8 +3004,23 @@
               }
             }
           },
+          "401": {
+            "description": "인증 실패 (X-WALLA-API-KEY 헤더 누락 또는 유효하지 않음)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
-            "description": "인증 실패 또는 권한 없음",
+            "description": "권한 없음",
             "content": {
               "application/json": {
                 "schema": {
@@ -2757,8 +3121,23 @@
               }
             }
           },
+          "401": {
+            "description": "인증 실패 (X-WALLA-API-KEY 헤더 누락 또는 유효하지 않음)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
-            "description": "인증 실패 또는 권한 없음",
+            "description": "권한 없음",
             "content": {
               "application/json": {
                 "schema": {

--- a/swagger.json
+++ b/swagger.json
@@ -2236,7 +2236,7 @@
     },
     "/open-api/v1/forms/{formId}/responses/search": {
       "post": {
-        "description": "제출된 응답 목록을 풍부한 필터와 함께 페이지네이션하여 조회합니다. `GET /open-api/v1/forms/{formId}/responses`와 동일한 응답 envelope을 반환하지만, parquet export(`POST .../exports/responses`)와 동일한 필터 계약(customerKeys, 제출일시 범위, hidden field, response field Tier A/B)을 본문으로 받습니다.\n\n**응답 데이터 구조**: 각 응답 객체는 폼 필드들의 값을 동적 속성으로 포함합니다. 필드 ID가 키이고, 값의 타입은 필드 타입에 따라 다릅니다. 필드 타입별 출력 형식은 `GET /open-api/v1/forms/{formId}/fields`로 조회하세요.\n\n**모든 필터는 선택**입니다. 본문이 비어 있으면 폼의 전체 제출 응답을 페이지 단위로 반환합니다. 둘 이상의 필터를 함께 보내면 모두 만족하는(AND) 응답만 포함됩니다.\n\n**마스킹 필드**: 응답 마스킹이 설정된 필드는 키는 유지되고 값이 문자열 `REDACTED`로 대체되어 반환됩니다. Open API에서는 마스킹 해제를 제공하지 않으며, 마스킹 필드를 필터 값으로 사용하는 것도 지원하지 않습니다(항상 0건 매칭).\n\n**pagination.totalCount는 필터를 적용한 전체 응답의 정확한 개수**입니다(현재 페이지가 마지막인지와 무관하게 COUNT(*) 기반 정확값).\n",
+        "description": "제출된 응답 목록을 풍부한 필터와 함께 페이지네이션하여 조회합니다. `GET /open-api/v1/forms/{formId}/responses`와 동일한 응답 envelope을 반환하지만, parquet export(`POST .../exports/responses`)와 동일한 필터 계약(customerKeys, 제출일시 범위, hidden field, response field Tier A/B)을 본문으로 받습니다.\n\n**응답 데이터 구조**: 각 응답 객체는 폼 필드들의 값을 동적 속성으로 포함합니다. 필드 ID가 키이고, 값의 타입은 필드 타입에 따라 다릅니다. 필드 타입별 출력 형식은 `GET /open-api/v1/forms/{formId}/fields`로 조회하세요.\n\n**모든 필터는 선택**입니다. 본문이 비어 있으면 폼의 전체 제출 응답을 페이지 단위로 반환합니다. 둘 이상의 필터를 함께 보내면 모두 만족하는(AND) 응답만 포함됩니다.\n\n**마스킹 필드**: 응답 마스킹이 설정된 필드는 키는 유지되고 값이 문자열 `REDACTED`로 대체되어 반환됩니다. Open API에서는 마스킹 해제를 제공하지 않으며, 마스킹 필드를 `responseFields` 필터로 사용하는 것은 지원되지 않습니다.\n\n**pagination.totalCount는 필터를 적용한 전체 응답의 정확한 개수**입니다(현재 페이지가 마지막인지와 무관하게 COUNT(*) 기반 정확값).\n",
         "security": [
           {
             "ApiKeyAuth": []

--- a/swagger.json
+++ b/swagger.json
@@ -781,7 +781,7 @@
     },
     "/open-api/v1/forms/{formId}/exports/field-definitions": {
       "post": {
-        "description": "폼의 필드 정의를 Parquet 파일로 내보냅니다. 응답 본문은 단일 Parquet 바이트 스트림이며 JSON 래핑이 없습니다.\n\n각 행은 하나의 필드를 나타내며 다음 컬럼을 포함합니다.\n- `fieldId`: 폼 필드 ID\n- `fieldType`: 필드 타입 (예: `SHORT_TEXT`, `RADIO`)\n- `label`: 사람이 읽을 수 있는 필드 라벨\n- `columnName`: 응답 Parquet에서 사용하는 컬럼명 (`f_<fieldId>` 형태)\n\n응답 export(`POST /open-api/v1/forms/{formId}/exports/responses`)와 함께 받아 `columnName ↔ label/fieldType`을 매핑하는 데 사용합니다.\n\n요청 본문은 사용하지 않습니다 (있어도 무시).\n",
+        "description": "폼의 필드 정의를 Parquet 파일로 내보냅니다. 응답 본문은 단일 Parquet 바이트 스트림이며 JSON 래핑이 없습니다.\n\n각 행은 하나의 필드를 나타내며 다음 컬럼을 포함합니다.\n- `fieldId`: 폼 필드 ID\n- `fieldType`: 필드 타입 (예: `SHORT_TEXT`, `RADIO`)\n- `label`: 사람이 읽을 수 있는 필드 라벨\n- `columnName`: 응답 Parquet에서 사용하는 컬럼명 (`f_<fieldId>` 형태)\n\n응답 export(`POST /open-api/v1/forms/{formId}/exports/responses`)와 함께 받아 `columnName ↔ label/fieldType`을 매핑하는 데 사용합니다.\n\n폼에 설정된 히든 필드도 행으로 포함됩니다 (`fieldType: HIDDEN`, `fieldId: hidden-<id>`, `columnName: f_hidden-<id>`). 응답 export의 히든 필드 값 컬럼과 매핑됩니다.\n\n요청 본문은 사용하지 않습니다 (있어도 무시).\n",
         "security": [
           {
             "ApiKeyAuth": []
@@ -836,7 +836,7 @@
     },
     "/open-api/v1/forms/{formId}/exports/responses": {
       "post": {
-        "description": "제출된 응답 데이터를 Parquet 파일로 내보냅니다. 응답 본문은 단일 Parquet 바이트 스트림이며 JSON 래핑이 없습니다. 데이터 파이프라인에서 그대로 받아 처리할 수 있습니다.\n\nParquet 컬럼명은 내부 식별자(`f_<fieldId>` 형태)로 들어 있습니다. 사람이 읽을 수 있는 라벨/타입과 매핑하려면 동반 엔드포인트인 `POST /open-api/v1/forms/{formId}/exports/field-definitions`로 필드 정의 Parquet을 함께 받아 join하세요.\n\n모든 필터는 선택입니다. 본문이 비어 있으면 폼의 전체 제출 응답을 반환합니다. 둘 이상의 필터를 함께 보내면 모두 만족하는(AND) 응답만 포함됩니다.\n",
+        "description": "제출된 응답 데이터를 Parquet 파일로 내보냅니다. 응답 본문은 단일 Parquet 바이트 스트림이며 JSON 래핑이 없습니다. 데이터 파이프라인에서 그대로 받아 처리할 수 있습니다.\n\nParquet 컬럼명은 내부 식별자(`f_<fieldId>` 형태)로 들어 있습니다. 사람이 읽을 수 있는 라벨/타입과 매핑하려면 동반 엔드포인트인 `POST /open-api/v1/forms/{formId}/exports/field-definitions`로 필드 정의 Parquet을 함께 받아 join하세요.\n\n폼에 설정된 히든 필드의 제출 값도 `f_hidden-<fieldId>` 컬럼으로 함께 내보냅니다. 라벨 매핑은 필드 정의 export에 포함된 `HIDDEN` 행으로 확인하세요.\n\n모든 필터는 선택입니다. 본문이 비어 있으면 폼의 전체 제출 응답을 반환합니다. 둘 이상의 필터를 함께 보내면 모두 만족하는(AND) 응답만 포함됩니다.\n",
         "security": [
           {
             "ApiKeyAuth": []


### PR DESCRIPTION
## 개요

Open API 응답 필터링 기능([PPRKD-4723](https://paprika-data-lab.atlassian.net/browse/PPRKD-4723))에 맞춰 개발자 문서를 갱신합니다. 코드 변경은 walla-next 쪽(별도)이며, 이 PR은 문서/스펙만 다룹니다.

## 변경 내용

### 새 엔드포인트 문서 (ko/en)
- `POST /open-api/v1/forms/{formId}/responses/search` 섹션 추가 (`developer-docs/responses`)
  - 전체 필터 계약(customerKeys, submittedFrom/To, hiddenFields, responseFields Tier A/B), 요청·응답 예시, 오류 코드(`detailsType`), 활동 로그/PII 보호 노트
  - 필터 의미론은 Parquet 문서의 표를 교차 참조(중복 최소화)
  - 마스킹 동작 노트: 목록/검색은 값을 정규식으로 가려 반환(필드 유지) — Parquet export(필드 제외)와 다름을 명시

### 기존 문서 정정
- GET 응답 목록: `customerKey` 쿼리 파라미터 문서화(누락돼 있었음), `totalCount`를 "필터 적용 전체 응답의 정확한 개수"로 명확화
- **parquet.mdx 실제 API와 불일치 정정**: `customerKey`→`customerKeys`(배열), `startDate`/`endDate`→`submittedFrom`/`submittedTo`, `hiddenFields`/`responseFields` 값은 문자열 타입으로(숫자/배열 예시 정정)

### 히든 필드 값 export 반영 (ko/en)
- 응답/필드정의 두 parquet export가 이제 히든 필드 값을 포함하도록 변경된 동작을 문서화(walla-next 커밋 `6d2e8142`)
  - 응답 export: 히든 필드 제출 값이 `f_hidden-<fieldId>` 컬럼으로 포함됨
  - 필드 정의 export: 히든 필드가 `fieldType: HIDDEN`, `fieldId: hidden-<id>` 행으로 포함됨

### 스펙
- 루트 `swagger.json`을 재생성된 Walla Open API 스펙과 동기화(`responses/search` + 두 export 라우트의 히든 필드 설명 포함, 그간 누락됐던 다른 엔드포인트 갱신 반영)

## 검증
- `fumadocs-mdx` 생성 통과, `<Callout>`/`<Cards>` 태그 균형 및 내부 앵커 링크 정합 확인

[PPRKD-4723]: https://paprika-data-lab.atlassian.net/browse/PPRKD-4723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ